### PR TITLE
fix(playerbot): Add missing SpellMgr.h includes - Phase 7B

### DIFF
--- a/src/modules/Playerbot/AI/BehaviorTree/Nodes/CombatNodes.h
+++ b/src/modules/Playerbot/AI/BehaviorTree/Nodes/CombatNodes.h
@@ -24,6 +24,7 @@
 #include "Unit.h"
 #include "Spell.h"
 #include "SpellInfo.h"
+#include "SpellMgr.h"
 #include "SharedDefines.h"
 
 namespace Playerbot

--- a/src/modules/Playerbot/AI/BehaviorTree/Nodes/HealingNodes.h
+++ b/src/modules/Playerbot/AI/BehaviorTree/Nodes/HealingNodes.h
@@ -24,6 +24,7 @@
 #include "Unit.h"
 #include "Group.h"
 #include "SpellInfo.h"
+#include "SpellMgr.h"
 
 namespace Playerbot
 {


### PR DESCRIPTION
- Added #include "SpellMgr.h" to CombatNodes.h
- Added #include "SpellMgr.h" to HealingNodes.h
- Fixes C2065 "sSpellMgr": Undeclared identifier errors

Baseline: 4283 errors (after Phase 7A: ~3743 expected)
Expected: ~3731 errors (12 C2065 sSpellMgr errors eliminated)

Root Cause: Files using sSpellMgr macro without including SpellMgr.h header where sSpellMgr is defined as SpellMgr::instance()

Files fixed: 2
Pattern: Added SpellMgr.h after last spell-related include

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  
-  
-  

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

(Does it build, tested in-game, etc.)


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
