### PR TITLE
fix(playerbot): Add Playerbot namespace wrapper to bot::ai classes

### DIFF
--- a/src/modules/Playerbot/AI/Decision/ActionPriorityQueue.cpp
+++ b/src/modules/Playerbot/AI/Decision/ActionPriorityQueue.cpp
@@ -13,6 +13,7 @@
 #include "Log.h"
 #include <algorithm>
 
+namespace Playerbot {
 namespace bot { namespace ai {
 
 // ============================================================================
@@ -369,3 +370,4 @@ const PrioritizedSpell* ActionPriorityQueue::FindSpell(uint32 spellId) const
 }
 
 }} // namespace bot::ai
+} // namespace Playerbot

--- a/src/modules/Playerbot/AI/Decision/ActionPriorityQueue.h
+++ b/src/modules/Playerbot/AI/Decision/ActionPriorityQueue.h
@@ -20,6 +20,7 @@
 class Player;
 class Unit;
 
+namespace Playerbot {
 namespace bot { namespace ai {
 
 // Forward declarations
@@ -260,3 +261,4 @@ private:
 };
 
 }} // namespace bot::ai
+} // namespace Playerbot

--- a/src/modules/Playerbot/AI/Decision/BehaviorTree.cpp
+++ b/src/modules/Playerbot/AI/Decision/BehaviorTree.cpp
@@ -10,6 +10,7 @@
 #include "Unit.h"
 #include "Log.h"
 
+namespace Playerbot {
 namespace bot { namespace ai {
 
 // ============================================================================
@@ -376,3 +377,4 @@ std::shared_ptr<BehaviorTree> CreateDPSBehaviorTree()
 }
 
 }} // namespace bot::ai
+} // namespace Playerbot

--- a/src/modules/Playerbot/AI/Decision/BehaviorTree.h
+++ b/src/modules/Playerbot/AI/Decision/BehaviorTree.h
@@ -19,6 +19,7 @@
 class Player;
 class Unit;
 
+namespace Playerbot {
 namespace bot { namespace ai {
 
 // Forward declarations
@@ -450,3 +451,4 @@ private:
 };
 
 }} // namespace bot::ai
+} // namespace Playerbot

--- a/src/modules/Playerbot/AI/Decision/DecisionFusionSystem.cpp
+++ b/src/modules/Playerbot/AI/Decision/DecisionFusionSystem.cpp
@@ -20,6 +20,7 @@
 #include <unordered_map>
 #include <sstream>
 
+namespace Playerbot {
 namespace bot { namespace ai {
 
 // Constructor with default weights
@@ -681,3 +682,4 @@ float DecisionFusionSystem::EvaluateScoringCategory(
 }
 
 }} // namespace bot::ai
+} // namespace Playerbot

--- a/src/modules/Playerbot/AI/Decision/DecisionFusionSystem.h
+++ b/src/modules/Playerbot/AI/Decision/DecisionFusionSystem.h
@@ -17,6 +17,7 @@
 class BotAI;
 class Unit;
 
+namespace Playerbot {
 namespace bot { namespace ai {
 
 enum class CombatContext : uint8;
@@ -311,5 +312,6 @@ private:
 };
 
 }} // namespace bot::ai
+} // namespace Playerbot
 
 #endif


### PR DESCRIPTION
Resolves 45+ C2027 "undefined type" errors for ActionPriorityQueue and related classes.

Root Cause:
- ActionPriorityQueue, BehaviorTree, DecisionFusionSystem were in ::bot::ai namespace
- BotAI.h forward-declares them as Playerbot::bot::ai::*
- Mismatch caused "undefined type" errors in refactored class specs

Changes:
1. Added Playerbot namespace wrapper to Decision system headers:
   - ActionPriorityQueue.h/cpp
   - BehaviorTree.h/cpp
   - DecisionFusionSystem.h/cpp

2. Namespace structure now matches:
   - Before: ::bot::ai::ActionPriorityQueue
   - After: Playerbot::bot::ai::ActionPriorityQueue
   - Matches BotAI.h forward declarations

Files modified: 6
Expected error reduction: ~45 errors (ActionPriorityQueue C2027)

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  
-  
-  

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

(Does it build, tested in-game, etc.)


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
