### PR TITLE
fix(playerbot): Resolve P0 critical compilation errors

### DIFF
--- a/src/modules/Playerbot/AI/Coordination/ZoneOrchestrator.h
+++ b/src/modules/Playerbot/AI/Coordination/ZoneOrchestrator.h
@@ -21,6 +21,7 @@
 #include "RaidOrchestrator.h"
 #include "Define.h"
 #include "ObjectGuid.h"
+#include "Position.h"
 #include <vector>
 #include <unordered_map>
 #include <memory>

--- a/src/modules/Playerbot/Core/DI/Interfaces/IPlayerbotCharacterDBInterface.h
+++ b/src/modules/Playerbot/Core/DI/Interfaces/IPlayerbotCharacterDBInterface.h
@@ -5,15 +5,11 @@
 #pragma once
 
 #include "Define.h"
+#include "DatabaseEnvFwd.h"
+#include "CharacterDatabase.h"
 #include <string>
 #include <functional>
 #include <thread>
-
-// Forward declarations
-class CharacterDatabasePreparedStatement;
-class PreparedQueryResult;
-class CharacterDatabaseTransaction;
-enum CharacterDatabaseStatements : uint32;
 
 namespace Playerbot
 {

--- a/src/modules/Playerbot/Core/DI/Interfaces/IPlayerbotDatabaseManager.h
+++ b/src/modules/Playerbot/Core/DI/Interfaces/IPlayerbotDatabaseManager.h
@@ -10,11 +10,9 @@
 #pragma once
 
 #include "Define.h"
+#include "DatabaseEnvFwd.h"
 #include <string>
 #include <memory>
-
-// Forward declaration
-class QueryResult;
 
 /**
  * @brief Interface for playerbot database operations

--- a/src/modules/Playerbot/Database/PlayerbotCharacterDBInterface.h
+++ b/src/modules/Playerbot/Database/PlayerbotCharacterDBInterface.h
@@ -339,7 +339,7 @@ namespace Playerbot
         ~SafeExecutionEngine();
 
         void Initialize();
-        void Shutdown() override;
+        void Shutdown();
 
         /**
          * Execute statement with comprehensive error handling

--- a/src/modules/Playerbot/Database/PlayerbotMigrationMgr.h
+++ b/src/modules/Playerbot/Database/PlayerbotMigrationMgr.h
@@ -64,17 +64,6 @@ public:
     bool CanRollback(std::string const& version) override;
 
     // Migration status and reporting
-    struct MigrationStatus
-    {
-        std::string currentVersion;
-        std::string targetVersion;
-        uint32 pendingCount;
-        uint32 appliedCount;
-        std::vector<std::string> pendingMigrations;
-        std::vector<std::string> failedMigrations;
-        bool isValid;
-    };
-
     MigrationStatus GetMigrationStatus() override;
     void PrintMigrationStatus() override;
 


### PR DESCRIPTION
Fixed 4 critical (P0) error patterns preventing compilation:

P0-1: ZoneOrchestrator.h missing Position.h
- Added #include "Position.h" to resolve C3646, C4430, C2061 errors
- Impact: High - blocks coordination systems

P0-2: Database type redefinitions (C2371 errors)
- IPlayerbotDatabaseManager.h: Replaced forward declaration with #include "DatabaseEnvFwd.h"
- IPlayerbotCharacterDBInterface.h: Replaced forward declarations with proper includes
- Fixed QueryResult, PreparedQueryResult, CharacterDatabasePreparedStatement, CharacterDatabaseTransaction conflicts
- Impact: High - blocks database operations

P0-3: SafeExecutionEngine::Shutdown override (C3668 error)
- Removed incorrect 'override' keyword from non-virtual method
- SafeExecutionEngine is not derived from any base class
- Impact: Medium - blocks database interface compilation

P0-4: PlayerbotMigrationMgr::GetMigrationStatus return type (C2555 error)
- Removed duplicate MigrationStatus struct definition
- Now uses inherited type from IPlayerbotMigrationMgr interface
- Impact: Medium - blocks migration manager compilation

Files modified: 5
Expected error reduction: ~50-100 errors (P0 + cascades)

Baseline: 2470 errors (post-Phase 7A)
Next: C2065 undeclared identifier errors (378 remaining)