### PR TITLE
fix(playerbot): Fix database type include order

### DIFF
--- a/src/modules/Playerbot/Database/PlayerbotCharacterDBInterface.cpp
+++ b/src/modules/Playerbot/Database/PlayerbotCharacterDBInterface.cpp
@@ -9,6 +9,7 @@
 
 #include "PlayerbotCharacterDBInterface.h"
 #include "DatabaseEnv.h"
+#include "CharacterDatabase.h"
 #include "QueryHolder.h"
 #include "Log.h"
 #include "World.h"

--- a/src/modules/Playerbot/Lifecycle/BotSpawner.cpp
+++ b/src/modules/Playerbot/Lifecycle/BotSpawner.cpp
@@ -35,6 +35,8 @@
 #include <cmath>
 
 #include "BotSpawner.h"
+#include "DatabaseEnv.h"
+#include "CharacterDatabase.h"
 #include "BotSessionMgr.h"
 #include "BotWorldSessionMgr.h"
 #include "BotResourcePool.h"
@@ -51,8 +53,6 @@
 #include "Player.h"
 #include "Random.h"
 #include "CharacterPackets.h"
-#include "DatabaseEnv.h"
-#include "CharacterDatabase.h"
 #include "Database/PlayerbotCharacterDBInterface.h"
 #include "ObjectGuid.h"
 #include "MotionMaster.h"

--- a/src/modules/Playerbot/Session/BotSession.cpp
+++ b/src/modules/Playerbot/Session/BotSession.cpp
@@ -3,6 +3,8 @@
  */
 
 #include "BotSession.h"
+#include "DatabaseEnv.h"
+#include "CharacterDatabase.h"
 #include "BotPacketRelay.h"
 #include "BotPacketSimulator.h"  // PHASE 1: Packet forging infrastructure
 #include "PacketDeferralClassifier.h"  // Selective main thread deferral
@@ -10,11 +12,9 @@
 #include "Log.h"
 #include "WorldPacket.h"
 #include "Player.h"
-#include "DatabaseEnv.h"
 #include "QueryHolder.h"
 #include "QueryCallback.h"
 #include "CharacterPackets.h"
-#include "CharacterDatabase.h"
 #include "Database/PlayerbotCharacterDBInterface.h"
 #include "World.h"
 #include "Map.h"


### PR DESCRIPTION
Resolves C2027 "undefined type" errors for database types.

Root Cause:
- CharacterDatabasePreparedStatement, PreparedQueryResult, QueryResult, CharacterDatabaseTransaction typedefs are in DatabaseEnvFwd.h
- These types need full template definitions from DatabaseEnv.h
- Include order was causing types to be used before full definition

Changes:
- Moved DatabaseEnv.h and CharacterDatabase.h to top of include lists
- BotSession.cpp: Database includes now immediately after self-include
- BotSpawner.cpp: Database includes now immediately after self-include
- PlayerbotCharacterDBInterface.cpp: Added CharacterDatabase.h

This ensures template PreparedStatement<T> and related types are fully defined before use.

Files modified: 3
Expected error reduction: ~60 errors (database type C2027)