### PR TITLE
fix(playerbot): Remove CooldownManager.cpp from CMakeLists.txt

### DIFF
--- a/src/modules/Playerbot/CMakeLists.txt
+++ b/src/modules/Playerbot/CMakeLists.txt
@@ -210,7 +210,7 @@ set(PLAYERBOT_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/AI/ClassAI/ClassAI.h
     ${CMAKE_CURRENT_SOURCE_DIR}/AI/ClassAI/ActionPriority.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/AI/ClassAI/ActionPriority.h
-    ${CMAKE_CURRENT_SOURCE_DIR}/AI/ClassAI/CooldownManager.cpp
+    # ${CMAKE_CURRENT_SOURCE_DIR}/AI/ClassAI/CooldownManager.cpp  # PHASE 47: Removed - using Common/CooldownManager.h (header-only)
     ${CMAKE_CURRENT_SOURCE_DIR}/AI/ClassAI/CooldownManager.h
     ${CMAKE_CURRENT_SOURCE_DIR}/AI/ClassAI/ResourceManager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/AI/ClassAI/ResourceManager.h


### PR DESCRIPTION
Problem: CMake error - cannot find CooldownManager.cpp source file
- CMake Error: Cannot find source file CooldownManager.cpp
- File was deleted in PHASE 47 but still referenced in CMakeLists.txt

Root Cause:
- PHASE 47 deleted AI/ClassAI/CooldownManager.cpp (legacy implementation)
- Replaced with header-only Common/CooldownManager.h
- CMakeLists.txt still had reference to deleted .cpp file

Fix Applied:
- Commented out CooldownManager.cpp from CMakeLists.txt line 213
- Added comment explaining it's now header-only
- Kept CooldownManager.h reference (redirect header)

Technical Details:
- Common/CooldownManager.h is header-only implementation
- CooldownManager.h redirects to Common/CooldownManager.h
- No separate .cpp file needed

Files Modified:
- src/modules/Playerbot/CMakeLists.txt

Impact: Resolves CMake configuration error