### PR TITLE
fix(playerbot): PHASE 106 - Fix namespace pollution (Playerbot::Playe…

### DIFF
--- a/buildlog.log.txt
+++ b/buildlog.log.txt
@@ -13,133 +13,506 @@ Building TrinityCore solution...
   argon2.vcxproj -> C:\TrinityBots\TrinityCore\build\dep\argon2\RelWithDebInfo\argon2.lib
   zlib.vcxproj -> C:\TrinityBots\TrinityCore\build\dep\zlib\RelWithDebInfo\zlib.lib
   fmt.vcxproj -> C:\TrinityBots\TrinityCore\build\dep\fmt\RelWithDebInfo\fmt.lib
-  openssl_ed25519.vcxproj -> C:\TrinityBots\TrinityCore\build\bin\RelWithDebInfo\openssl_ed25519.dll
   Recast.vcxproj -> C:\TrinityBots\TrinityCore\build\dep\recastnavigation\Recast\RelWithDebInfo\Recast.lib
-  g3dlib.vcxproj -> C:\TrinityBots\TrinityCore\build\dep\g3dlite\RelWithDebInfo\g3dlib.lib
   casc.vcxproj -> C:\TrinityBots\TrinityCore\build\dep\CascLib\RelWithDebInfo\casc.lib
   Detour.vcxproj -> C:\TrinityBots\TrinityCore\build\dep\recastnavigation\Detour\RelWithDebInfo\Detour.lib
+  g3dlib.vcxproj -> C:\TrinityBots\TrinityCore\build\dep\g3dlite\RelWithDebInfo\g3dlib.lib
+  openssl_ed25519.vcxproj -> C:\TrinityBots\TrinityCore\build\bin\RelWithDebInfo\openssl_ed25519.dll
   sfmt.vcxproj -> C:\TrinityBots\TrinityCore\build\dep\SFMT\RelWithDebInfo\sfmt.lib
   protobuf.vcxproj -> C:\TrinityBots\TrinityCore\build\dep\protobuf\RelWithDebInfo\protobuf.lib
   tbb.vcxproj -> C:\TrinityBots\TrinityCore\build\msvc_19.44_cxx20_64_md_relwithdebinfo\tbb12.lib
   GitRevision.cpp
   common.vcxproj -> C:\TrinityBots\TrinityCore\build\src\common\RelWithDebInfo\common.lib
-  network.vcxproj -> C:\TrinityBots\TrinityCore\build\src\common\network\RelWithDebInfo\trinity_network.lib
   database.vcxproj -> C:\TrinityBots\TrinityCore\build\src\server\database\RelWithDebInfo\database.lib
+  network.vcxproj -> C:\TrinityBots\TrinityCore\build\src\common\network\RelWithDebInfo\trinity_network.lib
   proto.vcxproj -> C:\TrinityBots\TrinityCore\build\src\server\proto\RelWithDebInfo\proto.lib
   vmap4assembler.vcxproj -> C:\TrinityBots\TrinityCore\build\bin\RelWithDebInfo\vmap4assembler.exe
+  extractor_common.vcxproj -> C:\TrinityBots\TrinityCore\build\src\tools\extractor_common\RelWithDebInfo\extractor_common.lib
   shared.vcxproj -> C:\TrinityBots\TrinityCore\build\src\server\shared\RelWithDebInfo\shared.lib
   modules-common.vcxproj -> C:\TrinityBots\TrinityCore\build\src\server\modules\Common\RelWithDebInfo\modules-common.lib
-     Bibliothek "C:/TrinityBots/TrinityCore/build/src/server/bnetserver/RelWithDebInfo/bnetserver.lib" und Objekt "C:/TrinityBots/TrinityCore/build/src/server/bnetserver/RelWithDebInfo/bnetserver.exp" werden erstellt.
   test-module.vcxproj -> C:\TrinityBots\TrinityCore\build\src\server\modules\TestModule\RelWithDebInfo\test-module.lib
+  PlayerbotModule.cpp
+  PlayerbotModuleAdapter.cpp
+  BotSession.cpp
   BotAI.cpp
   BotAI_HybridAI.cpp
   SpecializedAIFactory.cpp
   BehaviorTreeFactory.cpp
-  QuestStrategy.cpp
   ClassAI.cpp
   ClassBehaviorTreeRegistry.cpp
   DeathKnightAI.cpp
   DruidAI.cpp
   HunterAI.cpp
   MageAI.cpp
-  MonkAI.cpp
   RogueAI.cpp
   ShamanAI.cpp
   WarriorAI.cpp
+  BotSpawner.cpp
+  BotScheduler.cpp
   BotLifecycleMgr.cpp
+  BotSpawnOrchestrator.cpp
+  BotSpawnEventBus.cpp
+  BotSessionFactory.cpp
   RoleBasedCombatPositioning.cpp
   BotSpawnerAdapter.cpp
   PlayerbotWorldScript.cpp
   UnifiedLootManager.cpp
   UnifiedQuestManager.cpp
-  UnifiedMovementCoordinator.cpp
   BotGearFactory.cpp
   ProfessionAuctionBridge.cpp
   BankingManager.cpp
   DynamicQuestSystem.cpp
-  ObjectiveTracker.cpp
   AdvancedBehaviorManager.cpp
-  QuestCompletion.cpp
-  AdaptiveBehaviorManager.cpp
-  CombatBehaviorIntegration.cpp
-  bnetserver.vcxproj -> C:\TrinityBots\TrinityCore\build\bin\RelWithDebInfo\bnetserver.exe
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(66,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/Strategy/QuestStrategy.cpp“ wird kompiliert)
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotSpawner.cpp(34,9): warning C4005: "_USE_MATH_DEFINES": Makro-Neudefinition [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotSpawner.cpp(34,9):
+      „_USE_MATH_DEFINES“ wurde zuvor in der Befehlszeile deklariert
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(87,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/Strategy/QuestStrategy.cpp“ wird kompiliert)
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotScheduler.cpp(10,9): warning C4005: "_USE_MATH_DEFINES": Makro-Neudefinition [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotScheduler.cpp(10,9):
+      „_USE_MATH_DEFINES“ wurde zuvor in der Befehlszeile deklariert
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(88,38): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/Strategy/QuestStrategy.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,51): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/Strategy/QuestStrategy.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,40): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/Strategy/QuestStrategy.cpp“ wird kompiliert)
-  
+  mapextractor.vcxproj -> C:\TrinityBots\TrinityCore\build\bin\RelWithDebInfo\mapextractor.exe
   scripts.vcxproj -> C:\TrinityBots\TrinityCore\build\src\server\scripts\RelWithDebInfo\scripts.lib
-  extractor_common.vcxproj -> C:\TrinityBots\TrinityCore\build\src\tools\extractor_common\RelWithDebInfo\extractor_common.lib
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotSpawner.h(153,25): warning C4099: "std::default_delete<Playerbot::BotSpawner>": Geben Sie den zuerst unter Verwendung von "struct" und jetzt unter Verwendung von "class" gesehenen Namen ein [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotScheduler.h(269,24): error C2039: "OrderedRecursiveMutex" ist kein Member von "Playerbot::Playerbot". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotScheduler.h(27,11):
+      Siehe Deklaration von "Playerbot::Playerbot"
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotScheduler.h(269,45): error C2059: Syntaxfehler: "<" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotScheduler.h(269,57): error C3083: "LockOrder": Das Symbol links neben "::" muss ein Typ sein. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotScheduler.h(269,68): error C2039: "BOT_SPAWNER" ist kein Member von "Playerbot::Playerbot". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotScheduler.h(27,11):
+      Siehe Deklaration von "Playerbot::Playerbot"
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotScheduler.h(269,94): error C2238: Unerwartete(s) Token vor ";" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotScheduler.h(273,24): error C2039: "OrderedRecursiveMutex" ist kein Member von "Playerbot::Playerbot". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotScheduler.h(27,11):
+      Siehe Deklaration von "Playerbot::Playerbot"
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotScheduler.h(273,45): error C2059: Syntaxfehler: "<" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotScheduler.h(273,57): error C3083: "LockOrder": Das Symbol links neben "::" muss ein Typ sein. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotScheduler.h(273,68): error C2039: "BOT_SPAWNER" ist kein Member von "Playerbot::Playerbot". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotScheduler.h(27,11):
+      Siehe Deklaration von "Playerbot::Playerbot"
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotScheduler.h(273,95): error C2238: Unerwartete(s) Token vor ";" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotScheduler.h(278,24): error C2039: "OrderedRecursiveMutex" ist kein Member von "Playerbot::Playerbot". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotScheduler.h(27,11):
+      Siehe Deklaration von "Playerbot::Playerbot"
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotScheduler.h(278,45): error C2059: Syntaxfehler: "<" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotScheduler.h(278,57): error C3083: "LockOrder": Das Symbol links neben "::" muss ein Typ sein. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotScheduler.h(278,68): error C2039: "BOT_SPAWNER" ist kein Member von "Playerbot::Playerbot". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotScheduler.h(27,11):
+      Siehe Deklaration von "Playerbot::Playerbot"
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotScheduler.h(278,100): error C2238: Unerwartete(s) Token vor ";" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotPopulationManager.h(114,24): error C2039: "OrderedRecursiveMutex" ist kein Member von "Playerbot::Playerbot". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotPopulationManager.h(21,11):
+      Siehe Deklaration von "Playerbot::Playerbot"
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotPopulationManager.h(114,45): error C2059: Syntaxfehler: "<" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotPopulationManager.h(114,57): error C3083: "LockOrder": Das Symbol links neben "::" muss ein Typ sein. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotPopulationManager.h(114,68): error C2039: "BOT_SPAWNER" ist kein Member von "Playerbot::Playerbot". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotPopulationManager.h(21,11):
+      Siehe Deklaration von "Playerbot::Playerbot"
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotPopulationManager.h(114,97): error C2238: Unerwartete(s) Token vor ";" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotPopulationManager.h(134,24): error C2039: "OrderedRecursiveMutex" ist kein Member von "Playerbot::Playerbot". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotPopulationManager.h(21,11):
+      Siehe Deklaration von "Playerbot::Playerbot"
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotPopulationManager.h(134,45): error C2059: Syntaxfehler: "<" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotPopulationManager.h(134,57): error C3083: "LockOrder": Das Symbol links neben "::" muss ein Typ sein. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotPopulationManager.h(134,68): error C2039: "BOT_SPAWNER" ist kein Member von "Playerbot::Playerbot". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotPopulationManager.h(21,11):
+      Siehe Deklaration von "Playerbot::Playerbot"
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotPopulationManager.h(134,92): error C2238: Unerwartete(s) Token vor ";" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotSpawner.h(183,25): warning C4099: "std::default_delete<Playerbot::BotSpawner>": Geben Sie den zuerst unter Verwendung von "struct" und jetzt unter Verwendung von "class" gesehenen Namen ein [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotScheduler.cpp“ wird kompiliert)
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory(3301,8):
+      Siehe Deklaration von "std::default_delete<Playerbot::BotSpawner>"
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotSpawner.h(183,25): warning C4099: "std::default_delete<Playerbot::BotSpawner>": Geben Sie den zuerst unter Verwendung von "struct" und jetzt unter Verwendung von "class" gesehenen Namen ein [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/Adapters/BotSpawnerAdapter.cpp“ wird kompiliert)
       C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory(3301,8):
       Siehe Deklaration von "std::default_delete<Playerbot::BotSpawner>"
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Adapters\BotSpawnerAdapter.cpp(364,17): error C2280: "Playerbot::SpawnStats &Playerbot::SpawnStats::operator =(const Playerbot::SpawnStats &)" : Es wurde versucht, auf eine gelöschte Funktion zu verweisen [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotSpawner.h(81,1):
-      Compiler hat hier "Playerbot::SpawnStats::operator =" generiert
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotSpawner.h(81,1):
-      "Playerbot::SpawnStats &Playerbot::SpawnStats::operator =(const Playerbot::SpawnStats &)": Die Funktion wurde implizit gelöscht, weil eine Datenmember eine Funktion "std::atomic<unsigned int> &std::atomic<unsigned int>::operator =(const std::atomic<unsigned int> &)" aufruft, die gelöscht wurde oder nicht zugänglich ist.
-      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\atomic(2152,13):
-      "std::atomic<unsigned int> &std::atomic<unsigned int>::operator =(const std::atomic<unsigned int> &)": Die Funktion wurde explizit gelöscht.
+  vmap4extractor.vcxproj -> C:\TrinityBots\TrinityCore\build\bin\RelWithDebInfo\vmap4extractor.exe
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\deps\tbb\include\oneapi\tbb\detail\_namespace_injection.h(23,19): error C2039: "tbb" ist kein Member von "`global namespace'". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Adapters\BotSpawnerAdapter.cpp(598,16): error C2280: "Playerbot::SpawnStats &Playerbot::SpawnStats::operator =(const Playerbot::SpawnStats &)" : Es wurde versucht, auf eine gelöschte Funktion zu verweisen [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotSpawner.h(81,1):
-      Compiler hat hier "Playerbot::SpawnStats::operator =" generiert
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotSpawner.h(81,1):
-      "Playerbot::SpawnStats &Playerbot::SpawnStats::operator =(const Playerbot::SpawnStats &)": Die Funktion wurde implizit gelöscht, weil eine Datenmember eine Funktion "std::atomic<unsigned int> &std::atomic<unsigned int>::operator =(const std::atomic<unsigned int> &)" aufruft, die gelöscht wurde oder nicht zugänglich ist.
-      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\atomic(2152,13):
-      "std::atomic<unsigned int> &std::atomic<unsigned int>::operator =(const std::atomic<unsigned int> &)": Die Funktion wurde explizit gelöscht.
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\deps\tbb\include\oneapi\tbb\detail\_namespace_injection.h(23,19): error C2039: "tbb" ist kein Member von "`global namespace'". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Adapters\BotSpawnerAdapter.cpp(606,12): error C2280: "Playerbot::SpawnStats &Playerbot::SpawnStats::operator =(const Playerbot::SpawnStats &)" : Es wurde versucht, auf eine gelöschte Funktion zu verweisen [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotSpawner.h(81,1):
-      Compiler hat hier "Playerbot::SpawnStats::operator =" generiert
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotSpawner.h(81,1):
-      "Playerbot::SpawnStats &Playerbot::SpawnStats::operator =(const Playerbot::SpawnStats &)": Die Funktion wurde implizit gelöscht, weil eine Datenmember eine Funktion "std::atomic<unsigned int> &std::atomic<unsigned int>::operator =(const std::atomic<unsigned int> &)" aufruft, die gelöscht wurde oder nicht zugänglich ist.
-      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\atomic(2152,13):
-      "std::atomic<unsigned int> &std::atomic<unsigned int>::operator =(const std::atomic<unsigned int> &)": Die Funktion wurde explizit gelöscht.
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(33,48): error C2143: Syntaxfehler: Es fehlt ";" vor "*" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotSpawner.h(153,25): warning C4099: "std::default_delete<Playerbot::BotSpawner>": Geben Sie den zuerst unter Verwendung von "struct" und jetzt unter Verwendung von "class" gesehenen Namen ein [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(33,33): error C4430: Fehlender Typspezifizierer - int wird angenommen. Hinweis: "default-int" wird von C++ nicht unterstützt. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(33,58): warning C4229: Anachronismus verwendet: Modifizierer der Daten werden ignoriert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(33,58): error C4430: Fehlender Typspezifizierer - int wird angenommen. Hinweis: "default-int" wird von C++ nicht unterstützt. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(33,104): error C2059: Syntaxfehler: ")" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(34,48): error C2143: Syntaxfehler: Es fehlt ";" vor "*" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(34,33): error C4430: Fehlender Typspezifizierer - int wird angenommen. Hinweis: "default-int" wird von C++ nicht unterstützt. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(34,58): warning C4229: Anachronismus verwendet: Modifizierer der Daten werden ignoriert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(34,58): error C4430: Fehlender Typspezifizierer - int wird angenommen. Hinweis: "default-int" wird von C++ nicht unterstützt. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(34,106): error C2059: Syntaxfehler: ")" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(36,39): error C2143: Syntaxfehler: Es fehlt ";" vor "*" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(36,24): error C4430: Fehlender Typspezifizierer - int wird angenommen. Hinweis: "default-int" wird von C++ nicht unterstützt. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotScheduler.cpp(80,34): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(36,24): error C2732: Bindungsangaben widersprechen vorheriger Angabe für "Playerbot::std::pmr::memory_resource" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(36,24):
+      Siehe Deklaration von "Playerbot::std::pmr::memory_resource"
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(36,41): error C4430: Fehlender Typspezifizierer - int wird angenommen. Hinweis: "default-int" wird von C++ nicht unterstützt. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(36,79): error C2059: Syntaxfehler: "const" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(36,105): error C2143: Syntaxfehler: Es fehlt ";" vor "{" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(36,105): error C2447: "{": Funktionsheader fehlt - Parameterliste im alten Stil? [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(44,56): error C2146: Syntaxfehler: Fehlendes ";" vor Bezeichner "memory_resource" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(46,45): error C2516: "Playerbot::std::pmr::memory_resource": Keine zulässige Basisklasse [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(36,24):
+      Siehe Deklaration von "Playerbot::std::pmr::memory_resource"
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(48,26): error C4430: Fehlender Typspezifizierer - int wird angenommen. Hinweis: "default-int" wird von C++ nicht unterstützt. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(48,47): error C2143: Syntaxfehler: Es fehlt "," vor "&" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(48,14): error C3668: "Playerbot::std::pmr::_Identity_equal_resource::do_is_equal": Die Methode mit dem Überschreibungsspezifizierer "override" hat keine Basisklassenmethoden überschrieben. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(49,29): error C2065: "_That": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(55,15): error C3668: "Playerbot::std::pmr::_Unaligned_new_delete_resource_impl::do_allocate": Die Methode mit dem Überschreibungsspezifizierer "override" hat keine Basisklassenmethoden überschrieben. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(63,14): error C3668: "Playerbot::std::pmr::_Unaligned_new_delete_resource_impl::do_deallocate": Die Methode mit dem Überschreibungsspezifizierer "override" hat keine Basisklassenmethoden überschrieben. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(57,17): error C3861: "_Xbad_alloc": Bezeichner wurde nicht gefunden. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(73,15): error C3668: "Playerbot::std::pmr::_Aligned_new_delete_resource_impl::do_allocate": Die Methode mit dem Überschreibungsspezifizierer "override" hat keine Basisklassenmethoden überschrieben. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(81,14): error C3668: "Playerbot::std::pmr::_Aligned_new_delete_resource_impl::do_deallocate": Die Methode mit dem Überschreibungsspezifizierer "override" hat keine Basisklassenmethoden überschrieben. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(75,47): error C2065: "align_val_t": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(84,56): error C2065: "align_val_t": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(93,50): error C2143: Syntaxfehler: Es fehlt ";" vor "*" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(93,35): error C4430: Fehlender Typspezifizierer - int wird angenommen. Hinweis: "default-int" wird von C++ nicht unterstützt. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(93,35): error C2086: "int Playerbot::std::pmr::memory_resource": Neudefinition [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(36,24):
+      Siehe Deklaration von "Playerbot::std::pmr::memory_resource"
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(93,35): error C2732: Bindungsangaben widersprechen vorheriger Angabe für "Playerbot::std::pmr::memory_resource" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(93,35):
+      Siehe Deklaration von "Playerbot::std::pmr::memory_resource"
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(93,17): warning C4869: "nodiscard" kann nur auf Klassen, Enumerationen und Funktionen angewendet werden. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(93,52): error C4430: Fehlender Typspezifizierer - int wird angenommen. Hinweis: "default-int" wird von C++ nicht unterstützt. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(93,83): error C2059: Syntaxfehler: "{" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(93,83): error C2143: Syntaxfehler: Es fehlt ";" vor "{" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(93,83): error C2447: "{": Funktionsheader fehlt - Parameterliste im alten Stil? [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(233,40): error C2061: Syntaxfehler: Bezeichner "memory_resource" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(238,47): error C2061: Syntaxfehler: Bezeichner "memory_resource" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(238,9): error C2535: "Playerbot::std::pmr::unsynchronized_pool_resource::unsynchronized_pool_resource(void) noexcept": Memberfunktion bereits definiert oder deklariert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(229,9):
+      Siehe Deklaration von "Playerbot::std::pmr::unsynchronized_pool_resource::unsynchronized_pool_resource"
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(243,9): error C2535: "Playerbot::std::pmr::unsynchronized_pool_resource::unsynchronized_pool_resource(const Playerbot::std::pmr::pool_options &) noexcept": Memberfunktion bereits definiert oder deklariert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(232,9):
+      Siehe Deklaration von "Playerbot::std::pmr::unsynchronized_pool_resource::unsynchronized_pool_resource"
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(256,35): error C2143: Syntaxfehler: Es fehlt ";" vor "*" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(256,20): error C4430: Fehlender Typspezifizierer - int wird angenommen. Hinweis: "default-int" wird von C++ nicht unterstützt. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(256,9): warning C4869: "nodiscard" kann nur auf Klassen, Enumerationen und Funktionen angewendet werden. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(256,91): error C2334: Unerwartete(s) Token vor "{"; sichtbarer Funktionstext wird übersprungen [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(551,19): error C2039: "vector" ist kein Member von "Playerbot::std::pmr". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(32,11):
+      Siehe Deklaration von "Playerbot::std::pmr"
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(551,26): error C2275: "Playerbot::std::pmr::unsynchronized_pool_resource::_Pool": Es wurde ein Ausdruck anstelle eines Typs erwartet [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(551,32): error C2653: "pair": Keine Klasse oder Namespace [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(551,9): error C2903: "pair": Symbol ist weder eine Klassen-Vorlage noch eine Funktions-Vorlage. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(551,42): error C2059: Syntaxfehler: "," [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(552,64): error C2334: Unerwartete(s) Token vor "{"; sichtbarer Funktionstext wird übersprungen [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(564,14): error C2039: "vector" ist kein Member von "Playerbot::std::pmr". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(32,11):
+      Siehe Deklaration von "Playerbot::std::pmr"
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(564,14): error C7568: Nach der angenommenen Funktionsvorlage "vector" fehlt die Argumentliste. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(564,14): error C2062: "<error type>"-Typ unerwartet [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(564,34): error C2334: Unerwartete(s) Token vor "{"; sichtbarer Funktionstext wird übersprungen [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(251,10): error C3668: "Playerbot::std::pmr::unsynchronized_pool_resource::~unsynchronized_pool_resource": Die Methode mit dem Überschreibungsspezifizierer "override" hat keine Basisklassenmethoden überschrieben. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(285,15): error C3668: "Playerbot::std::pmr::unsynchronized_pool_resource::do_allocate": Die Methode mit dem Überschreibungsspezifizierer "override" hat keine Basisklassenmethoden überschrieben. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(299,14): error C3668: "Playerbot::std::pmr::unsynchronized_pool_resource::do_deallocate": Die Methode mit dem Überschreibungsspezifizierer "override" hat keine Basisklassenmethoden überschrieben. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(234,39): error C2065: "_Resource": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(234,32): error C2614: "Playerbot::std::pmr::unsynchronized_pool_resource": Unzulässige Elementinitialisierung: "_Pools" ist weder Basis noch Element [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(239,22): error C2065: "_Resource": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(239,15): error C2614: "Playerbot::std::pmr::unsynchronized_pool_resource": Unzulässige Elementinitialisierung: "_Pools" ist weder Basis noch Element [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(268,30): error C2065: "_Pools": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(268,24): error C2530: "_Al": Verweise müssen initialisiert werden [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(268,24): error C3531: "_Al": Ein Symbol, dessen Typ "auto" enthält, muss einen Initialisierer aufweisen. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(268,28): error C2143: Syntaxfehler: Es fehlt ";" vor ":" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(268,36): error C2143: Syntaxfehler: Es fehlt ";" vor ")" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(271,13): error C2065: "_Pools": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(272,13): error C2065: "_Pools": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(276,30): error C2059: Syntaxfehler: "const" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(280,17): error C2065: "_Resource": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(288,32): error C3861: "_Find_pool": Bezeichner wurde nicht gefunden. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(289,38): error C2065: "_Pools": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(290,37): error C2065: "_Pools": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(302,38): error C3861: "_Find_pool": Bezeichner wurde nicht gefunden. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(303,38): error C2065: "_Pools": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(346,17): error C3861: "_Xbad_alloc": Bezeichner wurde nicht gefunden. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(349,30): error C2059: Syntaxfehler: "const" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(350,48): error C2065: "_Resource": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(350,25): error C2737: "_Ptr": Das Objekt "const" muss initialisiert werden. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(374,13): error C3861: "upstream_resource": Bezeichner wurde nicht gefunden. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(433,34): error C2059: Syntaxfehler: "const" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(436,21): error C2065: "_Resource": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(499,32): error C2039: "upstream_resource" ist kein Member von "Playerbot::std::pmr::unsynchronized_pool_resource". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(228,24):
+      Siehe Deklaration von "Playerbot::std::pmr::unsynchronized_pool_resource"
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(515,34): error C2059: Syntaxfehler: "const" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory_resource(515,34): error C1003: Mehr als 100 Fehler gefunden; Kompilierung wird abgebrochen. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotScheduler.cpp(321,20): warning C4189: "endHour": Lokale Variable ist initialisiert aber nicht referenziert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotScheduler.cpp(357,86): warning C4100: „guid“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotSpawner.h(183,25): warning C4099: "std::default_delete<Playerbot::BotSpawner>": Geben Sie den zuerst unter Verwendung von "struct" und jetzt unter Verwendung von "class" gesehenen Namen ein [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotSpawnEventBus.cpp“ wird kompiliert)
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory(3301,8):
+      Siehe Deklaration von "std::default_delete<Playerbot::BotSpawner>"
+  
+  QuestCompletion.cpp
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotScheduler.cpp(595,92): warning C4100: „pattern“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotSpawner.h(183,25): warning C4099: "std::default_delete<Playerbot::BotSpawner>": Geben Sie den zuerst unter Verwendung von "struct" und jetzt unter Verwendung von "class" gesehenen Namen ein [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/PlayerbotModuleAdapter.cpp“ wird kompiliert)
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory(3301,8):
+      Siehe Deklaration von "std::default_delete<Playerbot::BotSpawner>"
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotSpawner.h(183,25): warning C4099: "std::default_delete<Playerbot::BotSpawner>": Geben Sie den zuerst unter Verwendung von "struct" und jetzt unter Verwendung von "class" gesehenen Namen ein [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotSpawner.cpp“ wird kompiliert)
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory(3301,8):
+      Siehe Deklaration von "std::default_delete<Playerbot::BotSpawner>"
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotSpawner.h(183,25): warning C4099: "std::default_delete<Playerbot::BotSpawner>": Geben Sie den zuerst unter Verwendung von "struct" und jetzt unter Verwendung von "class" gesehenen Namen ein [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
       C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory(3301,8):
       Siehe Deklaration von "std::default_delete<Playerbot::BotSpawner>"
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotSpawner.h(153,25): warning C4099: "std::default_delete<Playerbot::BotSpawner>": Geben Sie den zuerst unter Verwendung von "struct" und jetzt unter Verwendung von "class" gesehenen Namen ein [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotLifecycleMgr.cpp“ wird kompiliert)
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory(3630,35): error C2248: "Playerbot::BotSpawner::BotSpawner": Kein Zugriff auf private Member, dessen Deklaration in der Playerbot::BotSpawner-Klasse erfolgte. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Adapters/BotSpawnerAdapter.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotSpawner.h(186,5):
+      Siehe Deklaration von "Playerbot::BotSpawner::BotSpawner"
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotSpawner.h(113,19):
+      Siehe Deklaration von "Playerbot::BotSpawner"
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory(3630,35):
+      der Vorlageninstanziierungskontext (der älteste zuerst) ist
+          C:\TrinityBots\TrinityCore\src\modules\Playerbot\Adapters\BotSpawnerAdapter.cpp(401,33):
+          Siehe Verweis auf die gerade kompilierte Instanziierung "std::unique_ptr<Playerbot::BotSpawner,std::default_delete<Playerbot::BotSpawner>> std::make_unique<Playerbot::BotSpawner,,0>(void)" der Funktions-Vorlage.
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotSpawner.h(183,25): warning C4099: "std::default_delete<Playerbot::BotSpawner>": Geben Sie den zuerst unter Verwendung von "struct" und jetzt unter Verwendung von "class" gesehenen Namen ein [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/PlayerbotModule.cpp“ wird kompiliert)
       C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory(3301,8):
       Siehe Deklaration von "std::default_delete<Playerbot::BotSpawner>"
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotLifecycleMgr.cpp(134,34): warning C4018: ">=": Konflikt zwischen "signed" und "unsigned" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotLifecycleMgr.cpp(105,37): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotLifecycleMgr.cpp(612,60): warning C4100: „eventType“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotLifecycleMgr.cpp(812,45): error C2228: Links von ".load" müssen sich in einer Klasse/Struktur/Union befinden [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotLifecycleMgr.cpp(812,45):
-      Typ ist „uint32“
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Core\Events\BotEventTypes.h(178,57): warning C4100: „event“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/Banking/BankingManager.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(81,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(103,29): warning C4100: „cooldownMs“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(164,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Triggers\Trigger.h(83,43): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI.cpp“ wird kompiliert)
+  QuestTurnIn.cpp
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotSpawner.h(183,25): warning C4099: "std::default_delete<Playerbot::BotSpawner>": Geben Sie den zuerst unter Verwendung von "struct" und jetzt unter Verwendung von "class" gesehenen Namen ein [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Lifecycle/BotSpawnOrchestrator.cpp“ wird kompiliert)
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory(3301,8):
+      Siehe Deklaration von "std::default_delete<Playerbot::BotSpawner>"
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(81,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
@@ -150,183 +523,110 @@ C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(103,29): wa
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(164,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(81,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(103,29): warning C4100: „cooldownMs“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(164,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassAI.cpp“ wird kompiliert)
-  
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Triggers\Trigger.h(83,43): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Triggers\Trigger.h(83,43): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(66,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(87,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(88,38): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,51): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,40): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ObjectCache.h(100,31): warning C4100: „bot“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI.cpp“ wird kompiliert)
-  
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(81,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Monks/MonkAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(66,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(103,29): warning C4100: „cooldownMs“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Monks/MonkAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(87,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(88,38): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,51): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,40): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(164,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Monks/MonkAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(66,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(87,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(88,38): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,51): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,40): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ObjectCache.h(100,31): warning C4100: „bot“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Triggers\Trigger.h(83,43): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Monks/MonkAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ObjectCache.h(100,31): warning C4100: „bot“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(81,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Rogues/RogueAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(103,29): warning C4100: „cooldownMs“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Rogues/RogueAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(164,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Rogues/RogueAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(66,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Monks/MonkAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(87,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Monks/MonkAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(88,38): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Monks/MonkAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,51): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Monks/MonkAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,40): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Monks/MonkAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Triggers\Trigger.h(83,43): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Rogues/RogueAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(164,40): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,65): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,48): warning C4100: „spellId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(164,40): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,65): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,48): warning C4100: „spellId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ObjectCache.h(100,31): warning C4100: „bot“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Monks/MonkAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(81,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\Core\DI\Interfaces\IEquipmentManager.h(28,7): warning C4099: "ItemTemplate": Geben Sie den zuerst unter Verwendung von "struct" und jetzt unter Verwendung von "class" gesehenen Namen ein [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/Equipment/BotGearFactory.cpp“ wird kompiliert)
       C:\TrinityBots\TrinityCore\src\server\game\Entities\Player\Player.h(60,8):
       Siehe Deklaration von "ItemTemplate"
   
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(103,29): warning C4100: „cooldownMs“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
+  
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\Core\DI\Interfaces\IEquipmentManager.h(29,8): warning C4099: "ObjectGuid": Geben Sie den zuerst unter Verwendung von "class" und jetzt unter Verwendung von "struct" gesehenen Namen ein [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/Equipment/BotGearFactory.cpp“ wird kompiliert)
       C:\TrinityBots\TrinityCore\src\server\game\Entities\Object\ObjectGuid.h(267,19):
       Siehe Deklaration von "ObjectGuid"
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(81,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Shamans/ShamanAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(103,29): warning C4100: „cooldownMs“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Shamans/ShamanAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(103,29): warning C4100: „cooldownMs“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
-  
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(164,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Shamans/ShamanAI.cpp“ wird kompiliert)
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(81,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(103,29): warning C4100: „cooldownMs“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(66,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(87,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(164,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(164,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(88,38): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(81,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Hunters/HunterAI.cpp“ wird kompiliert)
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,51): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(103,29): warning C4100: „cooldownMs“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Hunters/HunterAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(164,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Hunters/HunterAI.cpp“ wird kompiliert)
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,40): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Triggers\Trigger.h(83,43): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Shamans/ShamanAI.cpp“ wird kompiliert)
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Core\Events\BotEventTypes.h(178,57): warning C4100: „event“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Banking/BankingManager.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ObjectCache.h(100,31): warning C4100: „bot“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Triggers\Trigger.h(83,43): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(66,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(87,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(88,38): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,51): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,40): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
+  
+  mmaps_generator.vcxproj -> C:\TrinityBots\TrinityCore\build\bin\RelWithDebInfo\mmaps_generator.exe
+  AdaptiveBehaviorManager.cpp
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ObjectCache.h(100,31): warning C4100: „bot“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(66,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(87,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(88,38): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,51): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,40): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(81,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(103,29): warning C4100: „cooldownMs“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(164,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ObjectCache.h(100,31): warning C4100: „bot“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(164,40): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
@@ -338,127 +638,215 @@ C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,48): warning C41
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Triggers\Trigger.h(83,43): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassAI.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Triggers\Trigger.h(83,43): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Triggers\Trigger.h(83,43): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(81,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Hunters/HunterAI.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(66,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Rogues/RogueAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(87,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Rogues/RogueAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(88,38): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Rogues/RogueAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,51): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Rogues/RogueAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,40): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Rogues/RogueAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(66,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(87,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(88,38): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,51): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,40): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(66,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Shamans/ShamanAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(87,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Shamans/ShamanAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(88,38): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Shamans/ShamanAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,51): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Shamans/ShamanAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,40): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Shamans/ShamanAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(66,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(87,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(88,38): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,51): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(164,40): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Monks/MonkAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,40): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,65): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Monks/MonkAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,48): warning C4100: „spellId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Monks/MonkAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ObjectCache.h(100,31): warning C4100: „bot“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Rogues/RogueAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(66,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(103,29): warning C4100: „cooldownMs“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Hunters/HunterAI.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(87,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Hunters/HunterAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(88,38): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Hunters/HunterAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,51): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Hunters/HunterAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,40): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(164,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Hunters/HunterAI.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(81,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(103,29): warning C4100: „cooldownMs“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ObjectCache.h(100,31): warning C4100: „bot“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Shamans/ShamanAI.cpp“ wird kompiliert)
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(164,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Triggers\Trigger.h(83,43): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Hunters/HunterAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Triggers\Trigger.h(83,43): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Common\StatusEffectTracker.h(178,16): warning C4189: "now": Lokale Variable ist initialisiert aber nicht referenziert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(164,40): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,65): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,48): warning C4100: „spellId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(66,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(87,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(88,38): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,51): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,40): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(81,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(103,29): warning C4100: „cooldownMs“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(164,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(164,40): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,65): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,48): warning C4100: „spellId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
+  
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ObjectCache.h(100,31): warning C4100: „bot“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Triggers\Trigger.h(83,43): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(66,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Hunters/HunterAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(87,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Hunters/HunterAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(88,38): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Hunters/HunterAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,51): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Hunters/HunterAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,40): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Hunters/HunterAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(66,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(87,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(88,38): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,51): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,40): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(81,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(103,29): warning C4100: „cooldownMs“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(164,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ObjectCache.h(100,31): warning C4100: „bot“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ObjectCache.h(100,31): warning C4100: „bot“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Hunters/HunterAI.cpp“ wird kompiliert)
   
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ObjectCache.h(100,31): warning C4100: „bot“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Triggers\Trigger.h(83,43): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(66,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(87,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(88,38): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,51): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,40): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(66,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(87,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(88,38): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,51): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,40): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ObjectCache.h(100,31): warning C4100: „bot“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(81,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ObjectCache.h(100,31): warning C4100: „bot“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(103,29): warning C4100: „cooldownMs“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(164,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
+  
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Triggers\Trigger.h(83,43): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(164,40): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,65): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,48): warning C4100: „spellId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(164,40): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,65): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,48): warning C4100: „spellId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
+  
+  CombatBehaviorIntegration.cpp
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(164,40): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Hunters/HunterAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,65): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Hunters/HunterAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,48): warning C4100: „spellId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Hunters/HunterAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(164,40): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,65): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,48): warning C4100: „spellId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(66,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
@@ -475,66 +863,196 @@ C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,51): 
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,40): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(164,40): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,65): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,48): warning C4100: „spellId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(164,40): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Shamans/ShamanAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,65): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Shamans/ShamanAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,48): warning C4100: „spellId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Shamans/ShamanAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(164,40): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,65): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,48): warning C4100: „spellId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
-  
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ObjectCache.h(100,31): warning C4100: „bot“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassAI.h(235,43): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(81,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(103,29): warning C4100: „cooldownMs“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(164,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(81,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Shamans/ShamanAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(103,29): warning C4100: „cooldownMs“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Shamans/ShamanAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(164,40): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,65): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,48): warning C4100: „spellId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(164,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Shamans/ShamanAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(81,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Rogues/RogueAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(103,29): warning C4100: „cooldownMs“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Rogues/RogueAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(164,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Rogues/RogueAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Triggers\Trigger.h(83,43): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Shamans/ShamanAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Triggers\Trigger.h(83,43): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Triggers\Trigger.h(83,43): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Rogues/RogueAI.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(81,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/DeathKnights/DeathKnightAI.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(103,29): warning C4100: „cooldownMs“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/DeathKnights/DeathKnightAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(164,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/DeathKnights/DeathKnightAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(164,40): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,65): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,48): warning C4100: „spellId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassAI.h(235,43): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(66,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Shamans/ShamanAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(87,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Shamans/ShamanAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(88,38): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Shamans/ShamanAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(66,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,51): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Shamans/ShamanAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,40): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Shamans/ShamanAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(87,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(88,38): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,51): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,40): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Triggers\Trigger.h(83,43): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/DeathKnights/DeathKnightAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ObjectCache.h(100,31): warning C4100: „bot“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Shamans/ShamanAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ObjectCache.h(100,31): warning C4100: „bot“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(66,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Rogues/RogueAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(87,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Rogues/RogueAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(88,38): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Rogues/RogueAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,51): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Rogues/RogueAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,40): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Rogues/RogueAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Common\StatusEffectTracker.h(178,16): warning C4189: "now": Lokale Variable ist initialisiert aber nicht referenziert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ObjectCache.h(100,31): warning C4100: „bot“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Rogues/RogueAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(66,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/DeathKnights/DeathKnightAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(87,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/DeathKnights/DeathKnightAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(88,38): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/DeathKnights/DeathKnightAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,51): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/DeathKnights/DeathKnightAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,40): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/DeathKnights/DeathKnightAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ObjectCache.h(100,31): warning C4100: „bot“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/DeathKnights/DeathKnightAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(164,40): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Shamans/ShamanAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,65): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Shamans/ShamanAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,48): warning C4100: „spellId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Shamans/ShamanAI.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassAI.h(235,43): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassAI.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(164,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/DeathKnights/DeathKnightAI.cpp“ wird kompiliert)
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassAI.h(235,43): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Hunters/HunterAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Core\DI\Interfaces\IDynamicQuestSystem.h(32,12): error C2011: "Playerbot::QuestStrategy": "unsigned enum" Typneudefinition [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Quest/UnifiedQuestManager.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Core\DI\Interfaces\IUnifiedQuestManager.h(41,12):
+      Siehe Deklaration von "Playerbot::QuestStrategy"
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(164,40): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Hunters/HunterAI.cpp“ wird kompiliert)
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
   
-  vmap4extractor.vcxproj -> C:\TrinityBots\TrinityCore\build\bin\RelWithDebInfo\vmap4extractor.exe
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,65): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Hunters/HunterAI.cpp“ wird kompiliert)
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,48): warning C4100: „spellId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Hunters/HunterAI.cpp“ wird kompiliert)
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Triggers\Trigger.h(83,43): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(164,40): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/DeathKnights/DeathKnightAI.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(81,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,65): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/DeathKnights/DeathKnightAI.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(103,29): warning C4100: „cooldownMs“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,48): warning C4100: „spellId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/DeathKnights/DeathKnightAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Common\StatusEffectTracker.h(178,16): warning C4189: "now": Lokale Variable ist initialisiert aber nicht referenziert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(164,40): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Rogues/RogueAI.cpp“ wird kompiliert)
@@ -545,103 +1063,35 @@ C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,65): warning C41
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,48): warning C4100: „spellId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Rogues/RogueAI.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(164,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Common\StatusEffectTracker.h(178,16): warning C4189: "now": Lokale Variable ist initialisiert aber nicht referenziert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Hunters/HunterAI.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(164,40): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.h(200,77): error C2027: Verwendung des undefinierten Typs "Playerbot::QuestStrategy" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Quest/UnifiedQuestManager.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Core\DI\Interfaces\IUnifiedQuestManager.h(41,12):
+      Siehe Deklaration von "Playerbot::QuestStrategy"
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,65): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,48): warning C4100: „spellId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Triggers\Trigger.h(83,43): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(66,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/DeathKnights/DeathKnightAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(87,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/DeathKnights/DeathKnightAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(88,38): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/DeathKnights/DeathKnightAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,51): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/DeathKnights/DeathKnightAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,40): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/DeathKnights/DeathKnightAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(81,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/Strategy/QuestStrategy.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(103,29): warning C4100: „cooldownMs“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/Strategy/QuestStrategy.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(164,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/Strategy/QuestStrategy.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ObjectCache.h(100,31): warning C4100: „bot“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/DeathKnights/DeathKnightAI.cpp“ wird kompiliert)
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.h(200,77): error C2065: "LEVEL_PROGRESSION": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Quest/UnifiedQuestManager.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassAI.h(235,43): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Monks/MonkAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Triggers\Trigger.h(83,43): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/Strategy/QuestStrategy.cpp“ wird kompiliert)
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ResourceManager.h(187,13): warning C4005: "MAX_RUNES": Makro-Neudefinition [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassAI.cpp“ wird kompiliert)
       C:\TrinityBots\TrinityCore\src\server\game\Entities\Player\Player.h(438,9):
       siehe vorherige Definition von "MAX_RUNES"
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ObjectCache.h(100,31): warning C4100: „bot“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/Strategy/QuestStrategy.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(66,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(87,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(88,38): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,51): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,40): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(164,40): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/DeathKnights/DeathKnightAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,65): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/DeathKnights/DeathKnightAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,48): warning C4100: „spellId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/DeathKnights/DeathKnightAI.cpp“ wird kompiliert)
-  
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassAI.h(235,43): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Shamans/ShamanAI.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(164,40): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/Strategy/QuestStrategy.cpp“ wird kompiliert)
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\UnifiedQuestManager.cpp(1526,94): error C2027: Verwendung des undefinierten Typs "Playerbot::QuestStrategy" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Core\DI\Interfaces\IUnifiedQuestManager.h(41,12):
+      Siehe Deklaration von "Playerbot::QuestStrategy"
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,65): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/Strategy/QuestStrategy.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,48): warning C4100: „spellId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/Strategy/QuestStrategy.cpp“ wird kompiliert)
-  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\UnifiedQuestManager.cpp(1526,94): error C2065: "LEVEL_PROGRESSION": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassAI.h(235,43): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Hunters/HunterAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ObjectCache.h(100,31): warning C4100: „bot“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Rogues/RogueAI.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\Core\Events\BotEventTypes.h(178,57): warning C4100: „event“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI.cpp“ wird kompiliert)
@@ -651,47 +1101,29 @@ C:\TrinityBots\TrinityCore\src\modules\Playerbot\Game\QuestManager.h(30,7): warn
       C:\TrinityBots\TrinityCore\src\server\game\Entities\Player\Player.h(60,8):
       Siehe Deklaration von "ItemTemplate"
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(81,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(103,29): warning C4100: „cooldownMs“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(164,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassAI.h(235,43): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/DeathKnights/DeathKnightAI.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Common\StatusEffectTracker.h(178,16): warning C4189: "now": Lokale Variable ist initialisiert aber nicht referenziert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Hunters/HunterAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Triggers\Trigger.h(83,43): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(164,40): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,65): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\CombatNodes.h(137,43): warning C4305: "Argument": Verkürzung von "double" in "float" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,48): warning C4100: „spellId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\CombatNodes.h(324,41): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassAI.h(235,43): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Rogues/RogueAI.cpp“ wird kompiliert)
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\CombatNodes.h(403,44): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(66,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\CombatNodes.h(464,44): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(87,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\CombatNodes.h(553,41): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(88,38): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,51): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,40): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\CombatNodes.h(577,44): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\Social\UnifiedLootManager.cpp(183,91): warning C4100: „item“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\Social\UnifiedLootManager.cpp(183,68): warning C4100: „group“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
@@ -699,119 +1131,23 @@ C:\TrinityBots\TrinityCore\src\modules\Playerbot\Social\UnifiedLootManager.cpp(2
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\Social\UnifiedLootManager.cpp(247,77): warning C4100: „group“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\Social\UnifiedLootManager.cpp(253,69): warning C4100: „group“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\Social\UnifiedLootManager.cpp(259,69): warning C4100: „group“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ObjectCache.h(100,31): warning C4100: „bot“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassAI.h(235,43): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/DeathKnights/DeathKnightAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\UnifiedQuestManager.cpp(299,113): warning C4100: „bot“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\UnifiedQuestManager.cpp(299,96): warning C4100: „questId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\UnifiedQuestManager.cpp(340,110): warning C4100: „bot“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\UnifiedQuestManager.cpp(340,93): warning C4100: „questId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\UnifiedQuestManager.cpp(356,103): warning C4100: „factionId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\UnifiedQuestManager.cpp(378,107): warning C4100: „bot“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\UnifiedQuestManager.cpp(378,90): warning C4100: „questId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(164,40): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,65): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,48): warning C4100: „spellId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\UnifiedQuestManager.cpp(764,5): error C2280: "Playerbot::TurnInMetrics::TurnInMetrics(const Playerbot::TurnInMetrics &)" : Es wurde versucht, auf eine gelöschte Funktion zu verweisen [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\QuestTurnIn.h(126,5):
-      Siehe Deklaration von "Playerbot::TurnInMetrics::TurnInMetrics"
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\QuestTurnIn.h(126,5):
-      "Playerbot::TurnInMetrics::TurnInMetrics(const Playerbot::TurnInMetrics &)": Die Funktion wurde explizit gelöscht.
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(81,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(103,29): warning C4100: „cooldownMs“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(164,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Triggers\Trigger.h(83,43): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassAI.h(235,43): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
-  
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\CombatNodes.h(137,43): warning C4305: "Argument": Verkürzung von "double" in "float" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\CombatNodes.h(324,41): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\CombatNodes.h(403,44): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\CombatNodes.h(464,44): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\CombatNodes.h(553,41): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\CombatNodes.h(577,44): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(66,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(87,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(88,38): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,51): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,40): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ObjectCache.h(100,31): warning C4100: „bot“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.h(200,77): error C2027: Verwendung des undefinierten Typs "Playerbot::QuestStrategy" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/Quest/DynamicQuestSystem.cpp“ wird kompiliert)
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Core\DI\Interfaces\IDynamicQuestSystem.h(27,12):
-      Siehe Deklaration von "Playerbot::QuestStrategy"
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.h(200,77): error C2065: "LEVEL_PROGRESSION": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/Quest/DynamicQuestSystem.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\CombatNodes.h(137,43): warning C4305: "Argument": Verkürzung von "double" in "float" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\CombatNodes.h(324,41): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\CombatNodes.h(403,44): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\CombatNodes.h(464,44): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\CombatNodes.h(553,41): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\CombatNodes.h(577,44): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(164,40): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,65): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,48): warning C4100: „spellId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\HealingNodes.h(559,44): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
@@ -819,21 +1155,11 @@ C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\HealingNo
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\HealingNodes.h(696,41): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassAI.h(235,43): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\HealingNodes.h(559,44): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Common\StatusEffectTracker.h(178,16): warning C4189: "now": Lokale Variable ist initialisiert aber nicht referenziert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Core\DI\Interfaces\IEquipmentManager.h(28,7): warning C4099: "ItemTemplate": Geben Sie den zuerst unter Verwendung von "struct" und jetzt unter Verwendung von "class" gesehenen Namen ein [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI.cpp“ wird kompiliert)
-      C:\TrinityBots\TrinityCore\src\server\game\Entities\Item\ItemTemplate.h(823,20):
-      Siehe Deklaration von "ItemTemplate"
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Core\DI\Interfaces\IEquipmentManager.h(29,8): warning C4099: "ObjectGuid": Geben Sie den zuerst unter Verwendung von "class" und jetzt unter Verwendung von "struct" gesehenen Namen ein [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI.cpp“ wird kompiliert)
-      C:\TrinityBots\TrinityCore\src\server\game\Entities\Object\ObjectGuid.h(267,19):
-      Siehe Deklaration von "ObjectGuid"
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\HealingNodes.h(696,41): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\MovementNodes.h(256,44): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
@@ -844,12 +1170,6 @@ C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\MovementN
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\MovementNodes.h(363,41): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\HealingNodes.h(559,44): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\HealingNodes.h(696,41): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
-  
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\MovementNodes.h(463,44): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
   
@@ -859,175 +1179,93 @@ C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\MovementN
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\MovementNodes.h(699,44): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Common\StatusEffectTracker.h(178,16): warning C4189: "now": Lokale Variable ist initialisiert aber nicht referenziert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\CombatNodes.h(137,43): warning C4305: "Argument": Verkürzung von "double" in "float" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\CombatNodes.h(324,41): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\CombatNodes.h(403,44): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\CombatNodes.h(464,44): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
-  
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\MovementNodes.h(256,44): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\MovementNodes.h(337,41): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\CombatNodes.h(553,41): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\MovementNodes.h(363,41): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\CombatNodes.h(577,44): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\MovementNodes.h(463,44): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\CombatNodes.h(137,43): warning C4305: "Argument": Verkürzung von "double" in "float" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\CombatNodes.h(324,41): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\CombatNodes.h(403,44): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\CombatNodes.h(464,44): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\MovementNodes.h(669,40): warning C4305: "Argument": Verkürzung von "double" in "float" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\MovementNodes.h(699,44): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\CombatNodes.h(553,41): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassAI.h(235,43): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\CombatNodes.h(577,44): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\BehaviorTreeFactory.cpp(67,37): warning C4100: „bb“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Common\RotationHelpers.h(285,68): warning C4305: "Argument": Verkürzung von "double" in "float" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Common\RotationHelpers.h(373,41): warning C4018: ">=": Konflikt zwischen "signed" und "unsigned" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassBehaviorTreeRegistry.cpp(719,58): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassBehaviorTreeRegistry.cpp(719,40): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassBehaviorTreeRegistry.cpp(725,62): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassBehaviorTreeRegistry.cpp(725,44): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassBehaviorTreeRegistry.cpp(731,63): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\BehaviorTreeFactory.cpp(88,37): warning C4100: „bb“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassBehaviorTreeRegistry.cpp(731,45): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassBehaviorTreeRegistry.cpp(738,65): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Common\RotationHelpers.h(285,68): warning C4305: "Argument": Verkürzung von "double" in "float" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
-  
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassBehaviorTreeRegistry.cpp(738,47): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassBehaviorTreeRegistry.cpp(744,65): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassBehaviorTreeRegistry.cpp(744,47): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\BehaviorTreeFactory.cpp(96,37): warning C4100: „bb“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassBehaviorTreeRegistry.cpp(750,64): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\BehaviorTreeFactory.cpp(96,19): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassBehaviorTreeRegistry.cpp(750,46): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassBehaviorTreeRegistry.cpp(757,59): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassBehaviorTreeRegistry.cpp(757,41): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Common\RotationHelpers.h(373,41): warning C4018: ">=": Konflikt zwischen "signed" und "unsigned" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
-  
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassBehaviorTreeRegistry.cpp(763,57): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Core\DI\Interfaces\IEquipmentManager.h(28,7): warning C4099: "ItemTemplate": Geben Sie den zuerst unter Verwendung von "struct" und jetzt unter Verwendung von "class" gesehenen Namen ein [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\server\game\Entities\Item\ItemTemplate.h(823,20):
+      Siehe Deklaration von "ItemTemplate"
+  
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassBehaviorTreeRegistry.cpp(763,39): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassBehaviorTreeRegistry.cpp(769,63): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Core\DI\Interfaces\IEquipmentManager.h(29,8): warning C4099: "ObjectGuid": Geben Sie den zuerst unter Verwendung von "class" und jetzt unter Verwendung von "struct" gesehenen Namen ein [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\server\game\Entities\Object\ObjectGuid.h(267,19):
+      Siehe Deklaration von "ObjectGuid"
+  
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassBehaviorTreeRegistry.cpp(769,45): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassAI.h(235,43): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(81,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/Combat/RoleBasedCombatPositioning.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(103,29): warning C4100: „cooldownMs“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/Combat/RoleBasedCombatPositioning.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(164,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/Combat/RoleBasedCombatPositioning.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\HealingNodes.h(559,44): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\HealingNodes.h(696,41): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Triggers\Trigger.h(83,43): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/Combat/RoleBasedCombatPositioning.cpp“ wird kompiliert)
-  
-C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory(3630,35): error C2665: "Playerbot::HybridAIController::HybridAIController": Keine überladene Funktion konnte alle Argumenttypen konvertieren [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\HybridAIController.h(60,5):
-      kann "Playerbot::HybridAIController::HybridAIController(Playerbot::BotAI *,Playerbot::Blackboard *)" sein
-          C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory(3630,35):
-          "Playerbot::HybridAIController::HybridAIController(Playerbot::BotAI *,Playerbot::Blackboard *)" : Konvertierung von Argument 2 von "Playerbot::SharedBlackboard *" in "Playerbot::Blackboard *" nicht möglich
-              C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory(3630,56):
-              Die Typen, auf die verwiesen wird, sind unabhängig; die Konvertierung erfordert eine reinterpret_cast-Umwandlung, eine C-Stil-Umwandlung oder eine in Klammern gesetzte Umwandlung im Funktionsstil.
-      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory(3630,35):
-      bei Anpassung der Argumentliste "(_Ty, Playerbot::SharedBlackboard *)"
-          with
-          [
-              _Ty=Playerbot::BotAI *
-          ]
-      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory(3630,35):
-      der Vorlageninstanziierungskontext (der älteste zuerst) ist
-          C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI_HybridAI.cpp(35,24):
-          Siehe Verweis auf die gerade kompilierte Instanziierung "std::unique_ptr<Playerbot::HybridAIController,std::default_delete<Playerbot::HybridAIController>> std::make_unique<Playerbot::HybridAIController,Playerbot::BotAI*,Playerbot::SharedBlackboard*&,0>(Playerbot::BotAI *&&,Playerbot::SharedBlackboard *&)" der Funktions-Vorlage.
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(66,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/Combat/RoleBasedCombatPositioning.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(87,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/Combat/RoleBasedCombatPositioning.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(88,38): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/Combat/RoleBasedCombatPositioning.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,51): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/Combat/RoleBasedCombatPositioning.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,40): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/Combat/RoleBasedCombatPositioning.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ObjectCache.h(100,31): warning C4100: „bot“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/Combat/RoleBasedCombatPositioning.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\MovementNodes.h(256,44): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\MovementNodes.h(337,41): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\MovementNodes.h(363,41): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
-  
-  mapextractor.vcxproj -> C:\TrinityBots\TrinityCore\build\bin\RelWithDebInfo\mapextractor.exe
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\MovementNodes.h(463,44): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\MovementNodes.h(669,40): warning C4305: "Argument": Verkürzung von "double" in "float" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\MovementNodes.h(699,44): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\BehaviorTreeFactory.cpp(67,37): warning C4100: „bb“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\BehaviorTreeFactory.cpp(88,37): warning C4100: „bb“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\BehaviorTreeFactory.cpp(96,37): warning C4100: „bb“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\BehaviorTreeFactory.cpp(96,19): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Common\StatusEffectTracker.h(178,16): warning C4189: "now": Lokale Variable ist initialisiert aber nicht referenziert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\BehaviorTreeFactory.cpp(121,37): warning C4100: „bb“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\BehaviorTreeFactory.cpp(128,19): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\BehaviorTreeFactory.cpp(170,37): warning C4100: „bb“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\BehaviorTreeFactory.cpp(170,19): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(81,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/Advanced/AdvancedBehaviorManager.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(103,29): warning C4100: „cooldownMs“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/Advanced/AdvancedBehaviorManager.cpp“ wird kompiliert)
-  
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\BehaviorTreeFactory.cpp(190,37): warning C4100: „bb“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\BehaviorTreeFactory.cpp(190,19): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\BehaviorTreeFactory.cpp(206,37): warning C4100: „bb“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\BehaviorTreeFactory.cpp(206,19): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\BehaviorTreeFactory.cpp(214,37): warning C4100: „bb“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\BehaviorTreeFactory.cpp(214,19): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(164,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/Advanced/AdvancedBehaviorManager.cpp“ wird kompiliert)
-  
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\BehaviorTreeFactory.cpp(258,19): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\BehaviorTreeFactory.cpp(278,37): warning C4100: „bb“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\BehaviorTreeFactory.cpp(278,19): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
@@ -1035,28 +1273,22 @@ C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\BehaviorTreeFac
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\BehaviorTreeFactory.cpp(297,19): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\BehaviorTreeFactory.cpp(316,37): warning C4100: „bb“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\BehaviorTreeFactory.cpp(316,19): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Triggers\Trigger.h(83,43): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/Advanced/AdvancedBehaviorManager.cpp“ wird kompiliert)
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Common\RotationHelpers.h(285,68): warning C4305: "Argument": Verkürzung von "double" in "float" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Common\RotationHelpers.h(373,41): warning C4018: ">=": Konflikt zwischen "signed" und "unsigned" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\BehaviorTreeFactory.cpp(372,37): warning C4100: „bb“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\BehaviorTreeFactory.cpp(404,37): warning C4100: „bb“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\BehaviorTreeFactory.cpp(404,19): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\BehaviorTreeFactory.cpp(428,37): warning C4100: „bb“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\BehaviorTreeFactory.cpp(428,19): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(164,40): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/Combat/RoleBasedCombatPositioning.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,65): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/Combat/RoleBasedCombatPositioning.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,48): warning C4100: „spellId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/Combat/RoleBasedCombatPositioning.cpp“ wird kompiliert)
-  
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Common\RotationHelpers.h(285,68): warning C4305: "Argument": Verkürzung von "double" in "float" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Hunters/HunterAI.cpp“ wird kompiliert)
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Common\RotationHelpers.h(373,41): warning C4018: ">=": Konflikt zwischen "signed" und "unsigned" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Hunters/HunterAI.cpp“ wird kompiliert)
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\BehaviorTreeFactory.cpp(485,41): warning C4100: „bb“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\BehaviorTreeFactory.cpp(485,23): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
@@ -1067,6 +1299,109 @@ C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\BehaviorTreeFac
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\BehaviorTreeFactory.cpp(529,37): warning C4100: „bb“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\BehaviorTreeFactory.cpp(529,19): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\BehaviorTreeFactory.cpp(546,19): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\HealingNodes.h(559,44): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\HealingNodes.h(696,41): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(81,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/Combat/RoleBasedCombatPositioning.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(103,29): warning C4100: „cooldownMs“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/Combat/RoleBasedCombatPositioning.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(164,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/Combat/RoleBasedCombatPositioning.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Triggers\Trigger.h(83,43): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/Combat/RoleBasedCombatPositioning.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\MovementNodes.h(256,44): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\MovementNodes.h(337,41): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\MovementNodes.h(363,41): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\MovementNodes.h(463,44): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\MovementNodes.h(669,40): warning C4305: "Argument": Verkürzung von "double" in "float" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BehaviorTree\Nodes\MovementNodes.h(699,44): warning C4100: „blackboard“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(66,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/Combat/RoleBasedCombatPositioning.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(87,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/Combat/RoleBasedCombatPositioning.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(88,38): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/Combat/RoleBasedCombatPositioning.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,51): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/Combat/RoleBasedCombatPositioning.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,40): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/Combat/RoleBasedCombatPositioning.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ObjectCache.h(100,31): warning C4100: „bot“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/Combat/RoleBasedCombatPositioning.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Common\RotationHelpers.h(285,68): warning C4305: "Argument": Verkürzung von "double" in "float" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Hunters/HunterAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Common\RotationHelpers.h(373,41): warning C4018: ">=": Konflikt zwischen "signed" und "unsigned" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Hunters/HunterAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotSpawner.h(183,25): warning C4099: "std::default_delete<Playerbot::BotSpawner>": Geben Sie den zuerst unter Verwendung von "struct" und jetzt unter Verwendung von "class" gesehenen Namen ein [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Session/BotSessionFactory.cpp“ wird kompiliert)
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory(3301,8):
+      Siehe Deklaration von "std::default_delete<Playerbot::BotSpawner>"
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\MovementIntegration.h(341,35): error C2059: Syntaxfehler: "Konstante" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\MovementIntegration.h(341,53): error C2238: Unerwartete(s) Token vor ";" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(164,40): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/Combat/RoleBasedCombatPositioning.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,65): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/Combat/RoleBasedCombatPositioning.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,48): warning C4100: „spellId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/Combat/RoleBasedCombatPositioning.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(81,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Advanced/AdvancedBehaviorManager.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(103,29): warning C4100: „cooldownMs“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Advanced/AdvancedBehaviorManager.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(164,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Advanced/AdvancedBehaviorManager.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\MovementIntegration.h(341,35): error C2059: Syntaxfehler: "Konstante" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\MovementIntegration.h(341,53): error C2238: Unerwartete(s) Token vor ";" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Triggers\Trigger.h(83,43): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Advanced/AdvancedBehaviorManager.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\CombatSpecializationTemplates.h(100,8): warning C4099: "Playerbot::RuneSystem": Geben Sie den zuerst unter Verwendung von "class" und jetzt unter Verwendung von "struct" gesehenen Namen ein [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ResourceTypes.h(30,7):
+      Siehe Deklaration von "Playerbot::RuneSystem"
+  
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(66,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/Advanced/AdvancedBehaviorManager.cpp“ wird kompiliert)
   
@@ -1086,11 +1421,66 @@ C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ObjectCache.h(100,31): warni
   (Quelldatei „../../../../src/modules/Playerbot/Advanced/AdvancedBehaviorManager.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\RoleBasedCombatPositioning.cpp(54,11): warning C4189: "optimalFacing": Lokale Variable ist initialisiert aber nicht referenziert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Equipment\BotGearFactory.cpp(161,85): warning C4100: „faction“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\RoleBasedCombatPositioning.cpp(176,46): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory(3630,35): error C2665: "Playerbot::HybridAIController::HybridAIController": Keine überladene Funktion konnte alle Argumenttypen konvertieren [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI_HybridAI.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\HybridAIController.h(60,5):
+      kann "Playerbot::HybridAIController::HybridAIController(Playerbot::BotAI *,Playerbot::Blackboard *)" sein
+          C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory(3630,35):
+          "Playerbot::HybridAIController::HybridAIController(Playerbot::BotAI *,Playerbot::Blackboard *)" : Konvertierung von Argument 2 von "Playerbot::SharedBlackboard *" in "Playerbot::Blackboard *" nicht möglich
+              C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory(3630,56):
+              Die Typen, auf die verwiesen wird, sind unabhängig; die Konvertierung erfordert eine reinterpret_cast-Umwandlung, eine C-Stil-Umwandlung oder eine in Klammern gesetzte Umwandlung im Funktionsstil.
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory(3630,35):
+      bei Anpassung der Argumentliste "(_Ty, Playerbot::SharedBlackboard *)"
+          with
+          [
+              _Ty=Playerbot::BotAI *
+          ]
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory(3630,35):
+      der Vorlageninstanziierungskontext (der älteste zuerst) ist
+          C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI_HybridAI.cpp(35,24):
+          Siehe Verweis auf die gerade kompilierte Instanziierung "std::unique_ptr<Playerbot::HybridAIController,std::default_delete<Playerbot::HybridAIController>> std::make_unique<Playerbot::HybridAIController,Playerbot::BotAI*,Playerbot::SharedBlackboard*&,0>(Playerbot::BotAI *&&,Playerbot::SharedBlackboard *&)" der Funktions-Vorlage.
+  
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\RoleBasedCombatPositioning.cpp(226,11): warning C4189: "cleaveStart": Lokale Variable ist initialisiert aber nicht referenziert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\RoleBasedCombatPositioning.cpp(227,11): warning C4189: "cleaveEnd": Lokale Variable ist initialisiert aber nicht referenziert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\RoleBasedCombatPositioning.cpp(243,23): warning C4305: "Initialisierung": Verkürzung von "double" in "float" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\RoleBasedCombatPositioning.cpp(375,72): warning C4100: „context“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\RoleBasedCombatPositioning.cpp(920,72): warning C4100: „requiredAngle“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\RoleBasedCombatPositioning.cpp(1025,20): warning C4305: "Initialisierung": Verkürzung von "double" in "float" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\RoleBasedCombatPositioning.cpp(1026,18): warning C4305: "Initialisierung": Verkürzung von "double" in "float" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\RoleBasedCombatPositioning.cpp(1019,63): warning C4100: „spreadDistance“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\CombatSpecializationTemplates.h(100,8): warning C4099: "Playerbot::RuneSystem": Geben Sie den zuerst unter Verwendung von "class" und jetzt unter Verwendung von "struct" gesehenen Namen ein [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ResourceTypes.h(30,7):
+      Siehe Deklaration von "Playerbot::RuneSystem"
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\MovementIntegration.h(341,35): error C2059: Syntaxfehler: "Konstante" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\MovementIntegration.h(341,53): error C2238: Unerwartete(s) Token vor ";" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\RoleBasedCombatPositioning.cpp(1218,18): warning C4305: "+=": Verkürzung von "double" in "float" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\RoleBasedCombatPositioning.cpp(1220,23): warning C4305: "+=": Verkürzung von "double" in "float" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Equipment\BotGearFactory.cpp(316,43): error C2664: "Item *Player::StoreNewItem(const ItemPosCountVec &,uint32,bool,ItemRandomBonusListId,const GuidSet &,ItemContext,const std::vector<int32,std::allocator<int>> *,bool)" : Konvertierung von Argument 7 von "bool" in "const std::vector<int32,std::allocator<int>> *" nicht möglich [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Equipment\BotGearFactory.cpp(316,140):
+      Die Konvertierung eines ganzzahligen Typs in einen Zeigertyp erfordert eine reinterpret_cast-Umwandlung, eine C-Stil-Umwandlung oder eine in Klammern gesetzte Umwandlung im Funktionsstil.
+      C:\TrinityBots\TrinityCore\src\server\game\Entities\Player\Player.h(1504,15):
+      Siehe Deklaration von "Player::StoreNewItem"
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Equipment\BotGearFactory.cpp(316,43):
+      bei Anpassung der Argumentliste "(ItemPosCountVec, const unsigned int, bool, ItemRandomBonusListId, GuidSet, ItemContext, bool)"
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\RoleBasedCombatPositioning.cpp(1524,45): error C2440: "return": "Playerbot::PositionMovementResult" kann nicht in "Playerbot::MovementResult" konvertiert werden [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\RoleBasedCombatPositioning.cpp(1524,45):
+      Kein benutzerdefinierter Konvertierungsoperator verfügbar, der diese Konvertierung durchführen kann, oder der Operator kann nicht aufgerufen werden
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\MovementIntegration.h(341,35): error C2059: Syntaxfehler: "Konstante" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Hunters/HunterAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\MovementIntegration.h(341,53): error C2238: Unerwartete(s) Token vor ";" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Hunters/HunterAI.cpp“ wird kompiliert)
+  
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(164,40): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/Advanced/AdvancedBehaviorManager.cpp“ wird kompiliert)
   
@@ -1100,9 +1490,24 @@ C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,65): warning C41
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,48): warning C4100: „spellId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/Advanced/AdvancedBehaviorManager.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\RoleBasedCombatPositioning.cpp(920,72): warning C4100: „requiredAngle“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\RoleBasedCombatPositioning.cpp(1025,20): warning C4305: "Initialisierung": Verkürzung von "double" in "float" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\RoleBasedCombatPositioning.cpp(1026,18): warning C4305: "Initialisierung": Verkürzung von "double" in "float" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Packets\SpellPacketBuilder.h(32,8): warning C4099: "SpellCastTargets": Geben Sie den zuerst unter Verwendung von "class" und jetzt unter Verwendung von "struct" gesehenen Namen ein [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassAI.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\server\game\Spells\SpellDefines.h(345,19):
+      Siehe Deklaration von "SpellCastTargets"
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Common\RotationHelpers.h(285,68): warning C4305: "Argument": Verkürzung von "double" in "float" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Common\RotationHelpers.h(373,41): warning C4018: ">=": Konflikt zwischen "signed" und "unsigned" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Banking\BankingManager.cpp(58,38): warning C4100: „elapsed“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Banking\BankingManager.cpp(519,68): warning C4100: „itemId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\CombatSpecializationTemplates.h(100,8): warning C4099: "Playerbot::RuneSystem": Geben Sie den zuerst unter Verwendung von "class" und jetzt unter Verwendung von "struct" gesehenen Namen ein [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ResourceTypes.h(30,7):
+      Siehe Deklaration von "Playerbot::RuneSystem"
+  
 C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\utility(479,17): error C2512: "Playerbot::UnifiedLootManager::CoordinationModule::LootSession::LootSession": Kein geeigneter Standardkonstruktor verfügbar [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/Social/UnifiedLootManager.cpp“ wird kompiliert)
       C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\utility(479,17):
@@ -1170,39 +1575,58 @@ C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.352
               _Tuple2=std::tuple<>
           ]
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\RoleBasedCombatPositioning.cpp(1019,63): warning C4100: „spreadDistance“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Packets\SpellPacketBuilder.h(32,8): warning C4099: "SpellCastTargets": Geben Sie den zuerst unter Verwendung von "class" und jetzt unter Verwendung von "struct" gesehenen Namen ein [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassAI.cpp“ wird kompiliert)
-      C:\TrinityBots\TrinityCore\src\server\game\Spells\SpellDefines.h(345,19):
-      Siehe Deklaration von "SpellCastTargets"
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\RoleBasedCombatPositioning.cpp(1218,18): warning C4305: "+=": Verkürzung von "double" in "float" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\RoleBasedCombatPositioning.cpp(1220,23): warning C4305: "+=": Verkürzung von "double" in "float" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\RoleBasedCombatPositioning.cpp(1524,45): error C2440: "return": "Playerbot::PositionMovementResult" kann nicht in "Playerbot::MovementResult" konvertiert werden [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\RoleBasedCombatPositioning.cpp(1524,45):
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Druids\GuardianDruidRefactored.h(725,20): error C2664: "void Playerbot::bot::ai::ActionPriorityQueue::AddCondition(uint32,std::function<bool (Player *,Unit *)>,const std::string &)" : Konvertierung von Argument 2 von "Playerbot::GuardianDruidRefactored::InitializeGuardianMechanics::<lambda_3>" in "std::function<bool (Player *,Unit *)>" nicht möglich [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Druids\GuardianDruidRefactored.h(731,13):
       Kein benutzerdefinierter Konvertierungsoperator verfügbar, der diese Konvertierung durchführen kann, oder der Operator kann nicht aufgerufen werden
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Decision\ActionPriorityQueue.h(177,10):
+      Siehe Deklaration von "Playerbot::bot::ai::ActionPriorityQueue::AddCondition"
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Druids\GuardianDruidRefactored.h(725,20):
+      bei Anpassung der Argumentliste "(const uint32, Playerbot::GuardianDruidRefactored::InitializeGuardianMechanics::<lambda_3>, const char [33])"
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassAI.cpp(486,44): warning C4100: „maxRange“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassAI.cpp(496,40): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassAI.cpp(506,38): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\MovementIntegration.h(341,32): error C2059: Syntaxfehler: "Konstante" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Druids\GuardianDruidRefactored.h(756,20): error C2664: "void Playerbot::bot::ai::ActionPriorityQueue::AddCondition(uint32,std::function<bool (Player *,Unit *)>,const std::string &)" : Konvertierung von Argument 2 von "Playerbot::GuardianDruidRefactored::InitializeGuardianMechanics::<lambda_6>" in "std::function<bool (Player *,Unit *)>" nicht möglich [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Druids\GuardianDruidRefactored.h(762,13):
+      Kein benutzerdefinierter Konvertierungsoperator verfügbar, der diese Konvertierung durchführen kann, oder der Operator kann nicht aufgerufen werden
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Decision\ActionPriorityQueue.h(177,10):
+      Siehe Deklaration von "Playerbot::bot::ai::ActionPriorityQueue::AddCondition"
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Druids\GuardianDruidRefactored.h(756,20):
+      bei Anpassung der Argumentliste "(const uint32, Playerbot::GuardianDruidRefactored::InitializeGuardianMechanics::<lambda_6>, const char [45])"
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\MovementIntegration.h(341,50): error C2238: Unerwartete(s) Token vor ";" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\MovementIntegration.h(341,32): error C2059: Syntaxfehler: "Konstante" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\CombatSpecializationTemplates.h(100,8): warning C4099: "Playerbot::RuneSystem": Geben Sie den zuerst unter Verwendung von "class" und jetzt unter Verwendung von "struct" gesehenen Namen ein [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Hunters/HunterAI.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ResourceTypes.h(30,7):
+      Siehe Deklaration von "Playerbot::RuneSystem"
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\MovementIntegration.h(341,50): error C2238: Unerwartete(s) Token vor ";" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Hunters/HunterAI.cpp“ wird kompiliert)
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Druids\GuardianDruidRefactored.h(951,21): error C2664: "std::shared_ptr<Playerbot::bot::ai::ConditionNode> Playerbot::bot::ai::Condition(const std::string &,std::function<bool (Player *,Unit *)>)" : Konvertierung von Argument 2 von "Playerbot::GuardianDruidRefactored::InitializeGuardianMechanics::<lambda_22>" in "std::function<bool (Player *,Unit *)>" nicht möglich [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Druids\GuardianDruidRefactored.h(955,21):
+      Kein benutzerdefinierter Konvertierungsoperator verfügbar, der diese Konvertierung durchführen kann, oder der Operator kann nicht aufgerufen werden
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Decision\BehaviorTree.h(485,41):
+      Siehe Deklaration von "Playerbot::bot::ai::Condition"
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Druids\GuardianDruidRefactored.h(951,21):
+      bei Anpassung der Argumentliste "(const char [32], Playerbot::GuardianDruidRefactored::InitializeGuardianMechanics::<lambda_22>)"
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Banking\BankingManager.cpp(58,38): warning C4100: „elapsed“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Professions\ProfessionAuctionBridge.cpp(53,63): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Druids\GuardianDruidRefactored.h(1105,29): error C2664: "std::shared_ptr<Playerbot::bot::ai::ConditionNode> Playerbot::bot::ai::Condition(const std::string &,std::function<bool (Player *,Unit *)>)" : Konvertierung von Argument 2 von "Playerbot::GuardianDruidRefactored::InitializeGuardianMechanics::<lambda_32>" in "std::function<bool (Player *,Unit *)>" nicht möglich [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Druids\GuardianDruidRefactored.h(1109,29):
+      Kein benutzerdefinierter Konvertierungsoperator verfügbar, der diese Konvertierung durchführen kann, oder der Operator kann nicht aufgerufen werden
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Decision\BehaviorTree.h(485,41):
+      Siehe Deklaration von "Playerbot::bot::ai::Condition"
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Druids\GuardianDruidRefactored.h(1105,29):
+      bei Anpassung der Argumentliste "(const char [31], Playerbot::GuardianDruidRefactored::InitializeGuardianMechanics::<lambda_32>)"
+  
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\Advanced\AdvancedBehaviorManager.cpp(51,7): warning C5038: Datenmember  "Playerbot::AdvancedBehaviorManager::m_activeEvent" wird nach Datenmember  "Playerbot::AdvancedBehaviorManager::m_currentBossFight" initialisiert. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\Advanced\AdvancedBehaviorManager.cpp(189,51): warning C4100: „dungeonId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassAI.cpp(905,27): error C2039: "StartCooldown" ist kein Member von "Playerbot::CooldownManager". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Common\CooldownManager.h(82,7):
-      Siehe Deklaration von "Playerbot::CooldownManager"
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\MovementIntegration.h(341,35): error C2059: Syntaxfehler: "Konstante" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Rogues/RogueAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\MovementIntegration.h(341,53): error C2238: Unerwartete(s) Token vor ";" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Rogues/RogueAI.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\Advanced\AdvancedBehaviorManager.cpp(379,16): error C2664: "SpellCastResult WorldObject::CastSpell(const CastSpellTargetArg &,uint32,const CastSpellExtraArgs &)" : Konvertierung von Argument 1 von "uint32" in "const CastSpellTargetArg &" nicht möglich [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
       C:\TrinityBots\TrinityCore\src\modules\Playerbot\Advanced\AdvancedBehaviorManager.cpp(379,26):
@@ -1274,187 +1698,28 @@ C:\TrinityBots\TrinityCore\src\modules\Playerbot\Advanced\AdvancedBehaviorManage
       C:\TrinityBots\TrinityCore\src\modules\Playerbot\Advanced\AdvancedBehaviorManager.cpp(379,16):
       bei Anpassung der Argumentliste "(uint32, bool, Creature *)"
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Banking\BankingManager.cpp(519,68): warning C4100: „itemId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Banking\BankingManager.cpp(558,17): error C2039: "GetRestBonus" ist kein Member von "Player". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-      C:\TrinityBots\TrinityCore\src\server\game\Entities\Player\Player.h(1173,19):
-      Siehe Deklaration von "Player"
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\ShamanAI.cpp(266,11): warning C4189: "behaviors": Lokale Variable ist initialisiert aber nicht referenziert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Professions\ProfessionAuctionBridge.cpp(53,63): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Advanced\AdvancedBehaviorManager.cpp(1678,36): warning C4305: "Argument": Verkürzung von "double" in "float" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\CombatSpecializationTemplates.h(100,8): warning C4099: "Playerbot::RuneSystem": Geben Sie den zuerst unter Verwendung von "class" und jetzt unter Verwendung von "struct" gesehenen Namen ein [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ResourceTypes.h(30,7):
-      Siehe Deklaration von "Playerbot::RuneSystem"
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\ShamanAI.cpp(595,11): warning C4189: "optimalRange": Lokale Variable ist initialisiert aber nicht referenziert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Mages\MageAI.cpp(154,39): warning C4018: ">=": Konflikt zwischen "signed" und "unsigned" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\Professions\ProfessionAuctionBridge.cpp(280,11): warning C4189: "profitMargin": Lokale Variable ist initialisiert aber nicht referenziert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\Professions\ProfessionAuctionBridge.cpp(323,79): warning C4100: „itemId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\Professions\ProfessionAuctionBridge.cpp(323,64): warning C4100: „player“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\CombatSpecializationTemplates.h(100,8): warning C4099: "Playerbot::RuneSystem": Geben Sie den zuerst unter Verwendung von "class" und jetzt unter Verwendung von "struct" gesehenen Namen ein [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Hunters/HunterAI.cpp“ wird kompiliert)
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ResourceTypes.h(30,7):
-      Siehe Deklaration von "Playerbot::RuneSystem"
-  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Advanced\AdvancedBehaviorManager.cpp(1678,36): warning C4305: "Argument": Verkürzung von "double" in "float" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\Professions\ProfessionAuctionBridge.cpp(548,69): warning C4100: „player“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\CombatBehaviorIntegration.cpp(155,30): warning C4189: "metrics": Lokale Variable ist initialisiert aber nicht referenziert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Professions\ProfessionAuctionBridge.cpp(731,12): warning C4189: "itemSubClass": Lokale Variable ist initialisiert aber nicht referenziert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Professions\ProfessionAuctionBridge.cpp(802,17): error C2039: "GetRestBonus" ist kein Member von "Player". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-      C:\TrinityBots\TrinityCore\src\server\game\Entities\Player\Player.h(1173,19):
-      Siehe Deklaration von "Player"
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\CombatBehaviorIntegration.cpp(471,56): warning C4018: "<": Konflikt zwischen "signed" und "unsigned" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Equipment\BotGearFactory.cpp(161,85): warning C4100: „faction“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\ShamanAI.cpp(3106,9): error C2664: "SpellCastResult Playerbot::ClassAI::CastSpell(uint32,Unit *)" : Konvertierung von Argument 1 von "Player *" in "uint32" nicht möglich [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\ShamanAI.cpp(3106,25):
-      Es gibt keinen Kontext, in dem diese Konvertierung möglich ist
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassAI.h(279,23):
-      Siehe Deklaration von "Playerbot::ClassAI::CastSpell"
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\ShamanAI.cpp(3106,9):
-      bei Anpassung der Argumentliste "(Player *, Playerbot::UtilitySpells)"
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Monks\MonkAI.cpp(549,35): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Monks\MonkAI.cpp(845,39): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Monks\MonkAI.cpp(859,45): warning C4018: ">=": Konflikt zwischen "signed" und "unsigned" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Common\RotationHelpers.h(285,68): warning C4305: "Argument": Verkürzung von "double" in "float" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Common\RotationHelpers.h(373,41): warning C4018: ">=": Konflikt zwischen "signed" und "unsigned" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Monks\MonkAI.cpp(1616,45): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Monks\MonkAI.cpp(1658,45): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Monks\MonkAI.cpp(1718,40): warning C4100: „spellId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Equipment\BotGearFactory.cpp(316,43): error C2664: "Item *Player::StoreNewItem(const ItemPosCountVec &,uint32,bool,ItemRandomBonusListId,const GuidSet &,ItemContext,const std::vector<int32,std::allocator<int>> *,bool)" : Konvertierung von Argument 7 von "bool" in "const std::vector<int32,std::allocator<int>> *" nicht möglich [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Equipment\BotGearFactory.cpp(316,140):
-      Die Konvertierung eines ganzzahligen Typs in einen Zeigertyp erfordert eine reinterpret_cast-Umwandlung, eine C-Stil-Umwandlung oder eine in Klammern gesetzte Umwandlung im Funktionsstil.
-      C:\TrinityBots\TrinityCore\src\server\game\Entities\Player\Player.h(1504,15):
-      Siehe Deklaration von "Player::StoreNewItem"
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Equipment\BotGearFactory.cpp(316,43):
-      bei Anpassung der Argumentliste "(ItemPosCountVec, const unsigned int, bool, ItemRandomBonusListId, GuidSet, ItemContext, bool)"
-  
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Warriors\FuryWarriorRefactored.h(73,11): warning C5038: Datenmember  "Playerbot::FuryWarriorRefactored::_lastRampage" wird nach Datenmember  "Playerbot::FuryWarriorRefactored::_furiousSlashStacks" initialisiert. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\xutility(472,14): error C2672: "std::construct_at": keine übereinstimmende überladene Funktion gefunden [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
-      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\xutility(461,16):
-      kann "_Ty *std::construct_at(_Ty *const ,_Types ...) noexcept(<expr>)" sein
-          C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\xutility(472,14):
-          Die zugeordneten Einschränkungen werden nicht erfüllt.
-              C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\xutility(459,50):
-              "Playerbot::BTCastHeal::BTCastHeal": Kein geeigneter Standardkonstruktor verfügbar
-                  C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\xutility(459,50):
-                  bei Anpassung der Argumentliste "()"
-      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\xutility(472,14):
-      der Vorlageninstanziierungskontext (der älteste zuerst) ist
-          C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassBehaviorTreeRegistry.cpp(162,34):
-          Siehe Verweis auf die gerade kompilierte Instanziierung "std::shared_ptr<Playerbot::BTCastHeal> std::make_shared<Playerbot::BTCastHeal,>(void)" der Funktions-Vorlage.
-          C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory(2913,46):
-          Siehe Verweis auf die gerade kompilierte Instanziierung "std::_Ref_count_obj2<Playerbot::BTCastHeal>::_Ref_count_obj2<>(void)" der Funktions-Vorlage.
-          C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory(2100,18):
-          Siehe Verweis auf die gerade kompilierte Instanziierung "void std::_Construct_in_place<_Ty,>(_Ty &) noexcept(false)" der Funktions-Vorlage.
-          with
-          [
-              _Ty=Playerbot::BTCastHeal
-          ]
-  
-C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\xutility(476,61): error C2512: "Playerbot::BTCastHeal::BTCastHeal": Kein geeigneter Standardkonstruktor verfügbar [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
-      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\xutility(476,61):
-      bei Anpassung der Argumentliste "()"
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\MovementIntegration.h(341,32): error C2059: Syntaxfehler: "Konstante" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Rogues/RogueAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\MovementIntegration.h(341,50): error C2238: Unerwartete(s) Token vor ";" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Rogues/RogueAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(166,74): warning C4100: „situation“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(210,92): warning C4100: „situation“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1085,50): error C2027: Verwendung des undefinierten Typs "bot::ai::DecisionVote" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.h(29,12):
-      Siehe Deklaration von "bot::ai::DecisionVote"
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1085,50): error C2079: "Playerbot::AdaptiveBehaviorManager::GetRecommendedAction" verwendet undefiniertes struct "bot::ai::DecisionVote" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1090,18): error C2079: "vote" verwendet undefiniertes struct "bot::ai::DecisionVote" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1091,19): error C2653: "DecisionSource": Keine Klasse oder Namespace [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1091,35): error C2065: "ADAPTIVE_BEHAVIOR": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1292,38): error C2672: "std::max": keine übereinstimmende überladene Funktion gefunden [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\utility(85,26):
-      kann "_Ty std::max(std::initializer_list<_Elem>)" sein
-          C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1292,38):
-          „_Ty std::max(std::initializer_list<_Elem>)“ erwartet, dass 1 Argumente – 2 angegeben werden.
-      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\utility(82,26):
-      oder "_Ty std::max(std::initializer_list<_Elem>,_Pr)"
-      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\utility(74,6):
-      oder "const _Ty &std::max(const _Ty &,const _Ty &) noexcept(<expr>)"
-      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\utility(64,33):
-      oder "const _Ty &std::max(const _Ty &,const _Ty &,_Pr) noexcept(<expr>)"
-          C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1292,38):
-          „const _Ty &std::max(const _Ty &,const _Ty &,_Pr) noexcept(<expr>)“ erwartet, dass 3 Argumente – 2 angegeben werden.
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1292,27): error C2672: "std::min": keine übereinstimmende überladene Funktion gefunden [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\utility(109,26):
-      kann "_Ty std::min(std::initializer_list<_Elem>)" sein
-          C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1292,27):
-          „_Ty std::min(std::initializer_list<_Elem>)“ erwartet, dass 1 Argumente – 2 angegeben werden.
-      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\utility(106,26):
-      oder "_Ty std::min(std::initializer_list<_Elem>,_Pr)"
-      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\utility(98,6):
-      oder "const _Ty &std::min(const _Ty &,const _Ty &) noexcept(<expr>)"
-      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\utility(88,33):
-      oder "const _Ty &std::min(const _Ty &,const _Ty &,_Pr) noexcept(<expr>)"
-          C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1292,27):
-          „const _Ty &std::min(const _Ty &,const _Ty &,_Pr) noexcept(<expr>)“ erwartet, dass 3 Argumente – 2 angegeben werden.
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1095,5): warning C4390: ";": Leere kontrollierte Anweisung aufgetreten; ist dies beabsichtigt? [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Common\RotationHelpers.h(285,68): warning C4305: "Argument": Verkürzung von "double" in "float" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Common\RotationHelpers.h(373,41): warning C4018: ">=": Konflikt zwischen "signed" und "unsigned" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.cpp(915,35): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.cpp(933,38): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.cpp(1023,34): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.cpp(1077,40): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\ShamanAI.cpp(266,11): warning C4189: "behaviors": Lokale Variable ist initialisiert aber nicht referenziert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Professions\ProfessionAuctionBridge.cpp(731,12): warning C4189: "itemSubClass": Lokale Variable ist initialisiert aber nicht referenziert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\ShamanAI.cpp(595,11): warning C4189: "optimalRange": Lokale Variable ist initialisiert aber nicht referenziert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\CombatSpecializationTemplates.h(100,8): warning C4099: "Playerbot::RuneSystem": Geben Sie den zuerst unter Verwendung von "class" und jetzt unter Verwendung von "struct" gesehenen Namen ein [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Rogues/RogueAI.cpp“ wird kompiliert)
       C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ResourceTypes.h(30,7):
       Siehe Deklaration von "Playerbot::RuneSystem"
   
-  mmaps_generator.vcxproj -> C:\TrinityBots\TrinityCore\build\bin\RelWithDebInfo\mmaps_generator.exe
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Services\HealingTargetSelector.h(16,6): warning C5257: "DispelType": Die Enumeration wurde zuvor ohne einen festen zugrunde liegenden Typ deklariert. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.cpp(1912,33): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\MovementIntegration.h(341,32): error C2059: Syntaxfehler: "Konstante" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\MovementIntegration.h(341,35): error C2059: Syntaxfehler: "Konstante" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\MovementIntegration.h(341,50): error C2238: Unerwartete(s) Token vor ";" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\MovementIntegration.h(341,53): error C2238: Unerwartete(s) Token vor ";" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Common\RotationHelpers.h(285,68): warning C4305: "Argument": Verkürzung von "double" in "float" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Rogues/RogueAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Common\RotationHelpers.h(373,41): warning C4018: ">=": Konflikt zwischen "signed" und "unsigned" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Rogues/RogueAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Common\RotationHelpers.h(285,68): warning C4305: "Argument": Verkürzung von "double" in "float" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Common\RotationHelpers.h(373,41): warning C4018: ">=": Konflikt zwischen "signed" und "unsigned" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\DeathKnights\DeathKnightAI.cpp(970,30): warning C4018: "<": Konflikt zwischen "signed" und "unsigned" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Paladins\RetributionSpecializationRefactored.h(67,11): warning C5038: Datenmember  "Playerbot::RetributionPaladinRefactored::_sealTwistWindow" wird nach Datenmember  "Playerbot::RetributionPaladinRefactored::_cooldowns" initialisiert. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\CombatSpecializationTemplates.h(100,8): warning C4099: "Playerbot::RuneSystem": Geben Sie den zuerst unter Verwendung von "class" und jetzt unter Verwendung von "struct" gesehenen Namen ein [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ResourceTypes.h(30,7):
-      Siehe Deklaration von "Playerbot::RuneSystem"
   
 C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\xutility(472,14): error C2672: "std::construct_at": keine übereinstimmende überladene Funktion gefunden [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/BehaviorTree/BehaviorTreeFactory.cpp“ wird kompiliert)
@@ -1504,12 +1769,70 @@ C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.352
               _Ty=std::shared_ptr<Playerbot::BTCondition>
           ]
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\MovementIntegration.h(341,32): error C2059: Syntaxfehler: "Konstante" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\ShamanAI.cpp(3106,9): error C2664: "SpellCastResult Playerbot::ClassAI::CastSpell(uint32,Unit *)" : Konvertierung von Argument 1 von "Player *" in "uint32" nicht möglich [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\ShamanAI.cpp(3106,25):
+      Es gibt keinen Kontext, in dem diese Konvertierung möglich ist
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassAI.h(279,23):
+      Siehe Deklaration von "Playerbot::ClassAI::CastSpell"
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\ShamanAI.cpp(3106,9):
+      bei Anpassung der Argumentliste "(Player *, Playerbot::UtilitySpells)"
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\MovementIntegration.h(341,50): error C2238: Unerwartete(s) Token vor ";" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Druids\DruidAI.cpp(1372,42): warning C4018: ">=": Konflikt zwischen "signed" und "unsigned" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Druids\DruidAI.cpp(1608,38): warning C4018: ">=": Konflikt zwischen "signed" und "unsigned" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Services\HealingTargetSelector.h(16,6): warning C5257: "DispelType": Die Enumeration wurde zuvor ohne einen festen zugrunde liegenden Typ deklariert. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\xutility(472,14): error C2672: "std::construct_at": keine übereinstimmende überladene Funktion gefunden [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\xutility(461,16):
+      kann "_Ty *std::construct_at(_Ty *const ,_Types ...) noexcept(<expr>)" sein
+          C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\xutility(472,14):
+          Die zugeordneten Einschränkungen werden nicht erfüllt.
+              C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\xutility(459,50):
+              "Playerbot::BTCastHeal::BTCastHeal": Kein geeigneter Standardkonstruktor verfügbar
+                  C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\xutility(459,50):
+                  bei Anpassung der Argumentliste "()"
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\xutility(472,14):
+      der Vorlageninstanziierungskontext (der älteste zuerst) ist
+          C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ClassBehaviorTreeRegistry.cpp(162,34):
+          Siehe Verweis auf die gerade kompilierte Instanziierung "std::shared_ptr<Playerbot::BTCastHeal> std::make_shared<Playerbot::BTCastHeal,>(void)" der Funktions-Vorlage.
+          C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory(2913,46):
+          Siehe Verweis auf die gerade kompilierte Instanziierung "std::_Ref_count_obj2<Playerbot::BTCastHeal>::_Ref_count_obj2<>(void)" der Funktions-Vorlage.
+          C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory(2100,18):
+          Siehe Verweis auf die gerade kompilierte Instanziierung "void std::_Construct_in_place<_Ty,>(_Ty &) noexcept(false)" der Funktions-Vorlage.
+          with
+          [
+              _Ty=Playerbot::BTCastHeal
+          ]
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\xutility(476,61): error C2512: "Playerbot::BTCastHeal::BTCastHeal": Kein geeigneter Standardkonstruktor verfügbar [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp“ wird kompiliert)
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\xutility(476,61):
+      bei Anpassung der Argumentliste "()"
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Common\RotationHelpers.h(285,68): warning C4305: "Argument": Verkürzung von "double" in "float" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Rogues/RogueAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Common\RotationHelpers.h(373,41): warning C4018: ">=": Konflikt zwischen "signed" und "unsigned" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Rogues/RogueAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\CombatSpecializationTemplates.h(100,8): warning C4099: "Playerbot::RuneSystem": Geben Sie den zuerst unter Verwendung von "class" und jetzt unter Verwendung von "struct" gesehenen Namen ein [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ResourceTypes.h(30,7):
+      Siehe Deklaration von "Playerbot::RuneSystem"
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.cpp(915,35): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.cpp(933,38): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.cpp(1023,34): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.cpp(1077,40): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Paladins\RetributionSpecializationRefactored.h(67,11): warning C5038: Datenmember  "Playerbot::RetributionPaladinRefactored::_sealTwistWindow" wird nach Datenmember  "Playerbot::RetributionPaladinRefactored::_cooldowns" initialisiert. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.cpp(1912,33): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Warriors\FuryWarriorRefactored.h(73,11): warning C5038: Datenmember  "Playerbot::FuryWarriorRefactored::_lastRampage" wird nach Datenmember  "Playerbot::FuryWarriorRefactored::_furiousSlashStacks" initialisiert. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\DeathKnights\DeathKnightAI.cpp(970,30): warning C4018: "<": Konflikt zwischen "signed" und "unsigned" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\DeathKnights\DeathKnightAI.cpp(2028,57): error C2665: "Trinity::AnyUnfriendlyUnitInObjectRangeCheck::AnyUnfriendlyUnitInObjectRangeCheck": Keine überladene Funktion konnte alle Argumenttypen konvertieren [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
       C:\TrinityBots\TrinityCore\src\server\game\Grids\Notifiers\GridNotifiers.h(1193,13):
       kann "Trinity::AnyUnfriendlyUnitInObjectRangeCheck::AnyUnfriendlyUnitInObjectRangeCheck(const WorldObject *,const Unit *,float)" sein
@@ -1518,124 +1841,21 @@ C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\DeathKnights\DeathKn
       C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\DeathKnights\DeathKnightAI.cpp(2028,57):
       bei Anpassung der Argumentliste "(Player *, float, bool)"
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\DeathKnights\DeathKnightAI.cpp(2058,35): error C2039: "GetCreature" ist kein Member von "Playerbot::DoubleBufferedSpatialGrid". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Spatial\DoubleBufferedSpatialGrid.h(63,19):
-      Siehe Deklaration von "Playerbot::DoubleBufferedSpatialGrid"
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Hunters\BeastMasteryHunterRefactored.h(697,18): error C2039: "PetInfo" ist kein Member von "Playerbot". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Hunters\BeastMasteryHunterRefactored.h(35,11):
-      Siehe Deklaration von "Playerbot"
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Hunters\BeastMasteryHunterRefactored.h(697,26): error C3646: "GetPetInfo": Unbekannter Überschreibungsspezifizierer [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Hunters\BeastMasteryHunterRefactored.h(697,36): error C2059: Syntaxfehler: "(" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Hunters\BeastMasteryHunterRefactored.h(697,45): error C2334: Unerwartete(s) Token vor "{"; sichtbarer Funktionstext wird übersprungen [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\CombatSpecializationTemplates.h(100,8): warning C4099: "Playerbot::RuneSystem": Geben Sie den zuerst unter Verwendung von "class" und jetzt unter Verwendung von "struct" gesehenen Namen ein [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ResourceTypes.h(30,7):
-      Siehe Deklaration von "Playerbot::RuneSystem"
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Warriors\FuryWarriorRefactored.h(73,11): warning C5038: Datenmember  "Playerbot::FuryWarriorRefactored::_lastRampage" wird nach Datenmember  "Playerbot::FuryWarriorRefactored::_furiousSlashStacks" initialisiert. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Warriors/WarriorAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Hunters\HunterAI.cpp(1608,45): error C2039: "GetCreature" ist kein Member von "Playerbot::DoubleBufferedSpatialGrid". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Spatial\DoubleBufferedSpatialGrid.h(63,19):
-      Siehe Deklaration von "Playerbot::DoubleBufferedSpatialGrid"
-  
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Hunters\HunterAI.cpp(1932,48): warning C4018: ">=": Konflikt zwischen "signed" und "unsigned" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Hunters\MarksmanshipHunterRefactored.h(709,26): error C2027: Verwendung des undefinierten Typs "Playerbot::PetInfo" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Hunters\MarksmanshipHunterRefactored.h(39,8):
-      Siehe Deklaration von "Playerbot::PetInfo"
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Hunters\MarksmanshipHunterRefactored.h(709,74): error C2027: Verwendung des undefinierten Typs "Playerbot::PetInfo" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Hunters\MarksmanshipHunterRefactored.h(39,8):
-      Siehe Deklaration von "Playerbot::PetInfo"
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\MovementIntegration.h(341,32): error C2059: Syntaxfehler: "Konstante" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\MovementIntegration.h(341,50): error C2238: Unerwartete(s) Token vor ";" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Hunters\SurvivalHunterRefactored.h(911,26): error C2027: Verwendung des undefinierten Typs "Playerbot::PetInfo" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Hunters\MarksmanshipHunterRefactored.h(39,8):
-      Siehe Deklaration von "Playerbot::PetInfo"
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Hunters\SurvivalHunterRefactored.h(911,74): error C2027: Verwendung des undefinierten Typs "Playerbot::PetInfo" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Hunters\MarksmanshipHunterRefactored.h(39,8):
-      Siehe Deklaration von "Playerbot::PetInfo"
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Core\DI\Interfaces\IEquipmentManager.h(28,7): warning C4099: "ItemTemplate": Geben Sie den zuerst unter Verwendung von "struct" und jetzt unter Verwendung von "class" gesehenen Namen ein [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/Strategy/QuestStrategy.cpp“ wird kompiliert)
-      C:\TrinityBots\TrinityCore\src\server\game\Entities\Item\ItemTemplate.h(823,20):
-      Siehe Deklaration von "ItemTemplate"
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Core\DI\Interfaces\IEquipmentManager.h(29,8): warning C4099: "ObjectGuid": Geben Sie den zuerst unter Verwendung von "class" und jetzt unter Verwendung von "struct" gesehenen Namen ein [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/Strategy/QuestStrategy.cpp“ wird kompiliert)
-      C:\TrinityBots\TrinityCore\src\server\game\Entities\Object\ObjectGuid.h(267,19):
-      Siehe Deklaration von "ObjectGuid"
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\CombatSpecializationTemplates.h(100,8): warning C4099: "Playerbot::RuneSystem": Geben Sie den zuerst unter Verwendung von "class" und jetzt unter Verwendung von "struct" gesehenen Namen ein [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Mages/MageAI.cpp“ wird kompiliert)
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\ResourceTypes.h(30,7):
-      Siehe Deklaration von "Playerbot::RuneSystem"
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Druids\GuardianDruidRefactored.h(725,20): error C2664: "void Playerbot::bot::ai::ActionPriorityQueue::AddCondition(uint32,std::function<bool (Player *,Unit *)>,const std::string &)" : Konvertierung von Argument 2 von "Playerbot::GuardianDruidRefactored::InitializeGuardianMechanics::<lambda_3>" in "std::function<bool (Player *,Unit *)>" nicht möglich [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Druids\GuardianDruidRefactored.h(731,13):
-      Kein benutzerdefinierter Konvertierungsoperator verfügbar, der diese Konvertierung durchführen kann, oder der Operator kann nicht aufgerufen werden
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Decision\ActionPriorityQueue.h(177,10):
-      Siehe Deklaration von "Playerbot::bot::ai::ActionPriorityQueue::AddCondition"
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Druids\GuardianDruidRefactored.h(725,20):
-      bei Anpassung der Argumentliste "(const uint32, Playerbot::GuardianDruidRefactored::InitializeGuardianMechanics::<lambda_3>, const char [33])"
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Druids\GuardianDruidRefactored.h(756,20): error C2664: "void Playerbot::bot::ai::ActionPriorityQueue::AddCondition(uint32,std::function<bool (Player *,Unit *)>,const std::string &)" : Konvertierung von Argument 2 von "Playerbot::GuardianDruidRefactored::InitializeGuardianMechanics::<lambda_6>" in "std::function<bool (Player *,Unit *)>" nicht möglich [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Druids\GuardianDruidRefactored.h(762,13):
-      Kein benutzerdefinierter Konvertierungsoperator verfügbar, der diese Konvertierung durchführen kann, oder der Operator kann nicht aufgerufen werden
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Decision\ActionPriorityQueue.h(177,10):
-      Siehe Deklaration von "Playerbot::bot::ai::ActionPriorityQueue::AddCondition"
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Druids\GuardianDruidRefactored.h(756,20):
-      bei Anpassung der Argumentliste "(const uint32, Playerbot::GuardianDruidRefactored::InitializeGuardianMechanics::<lambda_6>, const char [45])"
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Druids\GuardianDruidRefactored.h(951,21): error C2664: "std::shared_ptr<Playerbot::bot::ai::ConditionNode> Playerbot::bot::ai::Condition(const std::string &,std::function<bool (Player *,Unit *)>)" : Konvertierung von Argument 2 von "Playerbot::GuardianDruidRefactored::InitializeGuardianMechanics::<lambda_22>" in "std::function<bool (Player *,Unit *)>" nicht möglich [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Druids\GuardianDruidRefactored.h(955,21):
-      Kein benutzerdefinierter Konvertierungsoperator verfügbar, der diese Konvertierung durchführen kann, oder der Operator kann nicht aufgerufen werden
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Decision\BehaviorTree.h(485,41):
-      Siehe Deklaration von "Playerbot::bot::ai::Condition"
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Druids\GuardianDruidRefactored.h(951,21):
-      bei Anpassung der Argumentliste "(const char [32], Playerbot::GuardianDruidRefactored::InitializeGuardianMechanics::<lambda_22>)"
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Druids\GuardianDruidRefactored.h(1105,29): error C2664: "std::shared_ptr<Playerbot::bot::ai::ConditionNode> Playerbot::bot::ai::Condition(const std::string &,std::function<bool (Player *,Unit *)>)" : Konvertierung von Argument 2 von "Playerbot::GuardianDruidRefactored::InitializeGuardianMechanics::<lambda_32>" in "std::function<bool (Player *,Unit *)>" nicht möglich [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/Druids/DruidAI.cpp“ wird kompiliert)
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Druids\GuardianDruidRefactored.h(1109,29):
-      Kein benutzerdefinierter Konvertierungsoperator verfügbar, der diese Konvertierung durchführen kann, oder der Operator kann nicht aufgerufen werden
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Decision\BehaviorTree.h(485,41):
-      Siehe Deklaration von "Playerbot::bot::ai::Condition"
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Druids\GuardianDruidRefactored.h(1105,29):
-      bei Anpassung der Argumentliste "(const char [31], Playerbot::GuardianDruidRefactored::InitializeGuardianMechanics::<lambda_32>)"
-  
+     Bibliothek "C:/TrinityBots/TrinityCore/build/src/server/bnetserver/RelWithDebInfo/bnetserver.lib" und Objekt "C:/TrinityBots/TrinityCore/build/src/server/bnetserver/RelWithDebInfo/bnetserver.exp" werden erstellt.
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Rogues\RogueAI.cpp(1381,31): warning C4018: "<": Konflikt zwischen "signed" und "unsigned" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Rogues\RogueAI.cpp(1619,57): warning C4018: ">=": Konflikt zwischen "signed" und "unsigned" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Warriors\WarriorAI.cpp(611,35): error C2039: "GetCreature" ist kein Member von "Playerbot::DoubleBufferedSpatialGrid". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Spatial\DoubleBufferedSpatialGrid.h(63,19):
-      Siehe Deklaration von "Playerbot::DoubleBufferedSpatialGrid"
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Mages\MageAI.cpp(154,39): warning C4018: ">=": Konflikt zwischen "signed" und "unsigned" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\QuestStrategy.cpp(747,19): warning C4018: ">=": Konflikt zwischen "signed" und "unsigned" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Druids\DruidAI.cpp(1372,42): warning C4018: ">=": Konflikt zwischen "signed" und "unsigned" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Druids\DruidAI.cpp(1608,38): warning C4018: ">=": Konflikt zwischen "signed" und "unsigned" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Session\BotSessionFactory.cpp(69,113): warning C4100: „request“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Session\BotSessionFactory.cpp(240,101): warning C4100: „characterGuid“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Session\BotSessionFactory.cpp(255,112): warning C4100: „request“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Session\BotSessionFactory.cpp(267,107): warning C4100: „request“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Session\BotSessionFactory.cpp(267,78): warning C4100: „session“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Session\BotSessionFactory.cpp(276,87): warning C4100: „session“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Session\BotSessionFactory.cpp(290,94): warning C4100: „level“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Session\BotSessionFactory.cpp(290,79): warning C4100: „session“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Session\BotSessionFactory.cpp(296,78): warning C4100: „session“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  bnetserver.vcxproj -> C:\TrinityBots\TrinityCore\build\bin\RelWithDebInfo\bnetserver.exe
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Session\BotSessionFactory.cpp(449,83): warning C4100: „characterGuid“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory(3308,27): error C2027: Verwendung des undefinierten Typs "Playerbot::HybridAIController" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/BotAI.cpp“ wird kompiliert)
       C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(313,11):
@@ -1665,54 +1885,6 @@ C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.352
       C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(313,11):
       Siehe Deklaration von "Playerbot::HybridAIController"
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotLifecycleMgr.h(37,8): error C2011: "PerformanceMetrics": "struct" Typneudefinition [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Core\DI\Interfaces\IPlayerbotConfig.h(26,8):
-      Siehe Deklaration von "PerformanceMetrics"
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Priests\ShadowPriestRefactored.h(285,11): error C2614: "Playerbot::ShadowPriestRefactored": Unzulässige Elementinitialisierung: "_cooldowns" ist weder Basis noch Element [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(66,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/Quest/QuestCompletion.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(87,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/Quest/QuestCompletion.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(88,38): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/Quest/QuestCompletion.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,51): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/Quest/QuestCompletion.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,40): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/Quest/QuestCompletion.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\QuestStrategy.cpp(1142,22): warning C4189: "spellInfo": Lokale Variable ist initialisiert aber nicht referenziert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\QuestStrategy.cpp(1240,28): warning C4389: "!=": Konflikt zwischen "signed" und "unsigned" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\QuestStrategy.cpp(1267,56): warning C4100: „questId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\QuestStrategy.cpp(1365,28): warning C4389: "==": Konflikt zwischen "signed" und "unsigned" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\DeathKnights\BloodDeathKnightRefactored.h(576,47): error C2039: "GetPlayerAI" ist kein Member von "Player". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
-      C:\TrinityBots\TrinityCore\src\server\game\Entities\Player\Player.h(1173,19):
-      Siehe Deklaration von "Player"
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\QuestStrategy.cpp(1471,28): warning C4389: "==": Konflikt zwischen "signed" und "unsigned" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(81,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/Quest/QuestCompletion.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(103,29): warning C4100: „cooldownMs“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/Quest/QuestCompletion.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(164,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/Quest/QuestCompletion.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Triggers\Trigger.h(83,43): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/Quest/QuestCompletion.cpp“ wird kompiliert)
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ObjectCache.h(100,31): warning C4100: „bot“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/Quest/QuestCompletion.cpp“ wird kompiliert)
-  
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(508,9): error C2059: Syntaxfehler: "if" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
@@ -1737,88 +1909,78 @@ C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationS
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(547,23): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(551,37): error C2065: "_riptideTracker": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(551,33): error C2065: "_riptideTracker": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(557,27): error C3861: "IsTankRole": Bezeichner wurde nicht gefunden. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(584,28): error C2065: "_earthShieldTracker": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(564,28): error C2065: "_earthShieldTracker": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(587,17): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(566,17): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(591,17): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(568,17): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(593,17): error C2065: "_earthShieldTracker": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(569,17): error C2065: "_earthShieldTracker": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(611,25): error C2065: "_riptideTracker": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(581,25): error C2065: "_riptideTracker": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(615,29): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(583,29): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(619,29): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(585,29): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(621,29): error C2065: "_riptideTracker": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(586,29): error C2065: "_riptideTracker": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(550,13): error C2440: "return": "bool" kann nicht in "Playerbot::RestorationShamanRefactored" konvertiert werden [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(549,13): error C2440: "return": "bool" kann nicht in "Playerbot::RestorationShamanRefactored" konvertiert werden [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(550,13):
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(549,13):
       "Playerbot::RestorationShamanRefactored::RestorationShamanRefactored(const Playerbot::RestorationShamanRefactored &)" : Konvertierung von Argument 1 von "bool" in "const Playerbot::RestorationShamanRefactored &" nicht möglich
-          C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(550,20):
+          C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(549,20):
           Ursache: Konvertierung von "bool" in "const Playerbot::RestorationShamanRefactored" nicht möglich
-          C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(550,20):
+          C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(549,20):
           Konvertierung erfordert einen zweiten benutzerdefinierten Konvertierungsoperator oder Konstruktor
-          C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(550,13):
+          C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(549,13):
           bei Anpassung der Argumentliste "(bool)"
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(567,21): error C2561: "Playerbot::HandleHoTs": Funktion muss einen Wert zurückgeben [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(570,17): error C2440: "return": "bool" kann nicht in "Playerbot::RestorationShamanRefactored" konvertiert werden [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(545,10):
-      Siehe Deklaration von "Playerbot::HandleHoTs"
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(575,21): error C2561: "Playerbot::HandleHoTs": Funktion muss einen Wert zurückgeben [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(545,10):
-      Siehe Deklaration von "Playerbot::HandleHoTs"
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(595,17): error C2440: "return": "bool" kann nicht in "Playerbot::RestorationShamanRefactored" konvertiert werden [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(595,17):
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(570,17):
       "Playerbot::RestorationShamanRefactored::RestorationShamanRefactored(const Playerbot::RestorationShamanRefactored &)" : Konvertierung von Argument 1 von "bool" in "const Playerbot::RestorationShamanRefactored &" nicht möglich
-          C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(595,24):
+          C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(570,24):
           Ursache: Konvertierung von "bool" in "const Playerbot::RestorationShamanRefactored" nicht möglich
-          C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(595,24):
+          C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(570,24):
           Konvertierung erfordert einen zweiten benutzerdefinierten Konvertierungsoperator oder Konstruktor
-          C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(595,17):
+          C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(570,17):
           bei Anpassung der Argumentliste "(bool)"
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(623,29): error C2440: "return": "bool" kann nicht in "Playerbot::RestorationShamanRefactored" konvertiert werden [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(587,29): error C2440: "return": "bool" kann nicht in "Playerbot::RestorationShamanRefactored" konvertiert werden [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(623,29):
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(587,29):
       "Playerbot::RestorationShamanRefactored::RestorationShamanRefactored(const Playerbot::RestorationShamanRefactored &)" : Konvertierung von Argument 1 von "bool" in "const Playerbot::RestorationShamanRefactored &" nicht möglich
-          C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(623,36):
+          C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(587,36):
           Ursache: Konvertierung von "bool" in "const Playerbot::RestorationShamanRefactored" nicht möglich
-          C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(623,36):
+          C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(587,36):
           Konvertierung erfordert einen zweiten benutzerdefinierten Konvertierungsoperator oder Konstruktor
-          C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(623,29):
+          C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(587,29):
           bei Anpassung der Argumentliste "(bool)"
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(633,9): error C2440: "return": "bool" kann nicht in "Playerbot::RestorationShamanRefactored" konvertiert werden [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(594,9): error C2440: "return": "bool" kann nicht in "Playerbot::RestorationShamanRefactored" konvertiert werden [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(633,9):
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(594,9):
       "Playerbot::RestorationShamanRefactored::RestorationShamanRefactored(const Playerbot::RestorationShamanRefactored &)" : Konvertierung von Argument 1 von "bool" in "const Playerbot::RestorationShamanRefactored &" nicht möglich
-          C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(633,16):
+          C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(594,16):
           Ursache: Konvertierung von "bool" in "const Playerbot::RestorationShamanRefactored" nicht möglich
-          C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(633,16):
+          C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(594,16):
           Konvertierung erfordert einen zweiten benutzerdefinierten Konvertierungsoperator oder Konstruktor
-          C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(633,9):
+          C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(594,9):
           bei Anpassung der Argumentliste "(bool)"
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(224,11): error C2614: "Playerbot::RestorationShamanRefactored": Unzulässige Elementinitialisierung: "_riptideTracker" ist weder Basis noch Element [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
@@ -1913,110 +2075,655 @@ C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationS
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(500,17): error C2065: "_lastSpiritLinkTotemTime": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(638,23): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(599,23): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(684,17): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(645,17): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(688,17): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(649,17): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(703,21): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(664,21): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(707,21): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(668,21): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(737,25): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(698,25): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(741,25): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(702,25): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(753,63): error C2065: "_lastCloudburstTotemTime": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(714,63): error C2065: "_lastCloudburstTotemTime": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(760,21): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(721,21): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(764,21): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(725,21): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(766,21): error C2065: "_lastCloudburstTotemTime": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(727,21): error C2065: "_lastCloudburstTotemTime": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(788,21): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(749,21): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(792,21): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(753,21): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(809,21): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(770,21): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(813,21): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(774,21): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(827,23): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(788,23): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(833,13): error C2065: "_riptideTracker": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(794,13): error C2065: "_riptideTracker": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(836,17): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(797,17): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(840,17): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(801,17): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(842,17): error C2065: "_riptideTracker": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(803,17): error C2065: "_riptideTracker": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(853,17): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(814,17): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(857,17): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(818,17): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(868,17): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(829,17): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(872,17): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(833,17): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(888,24): error C2270: "IsTankRole": Modifizierer für Funktionen, die keine Memberfunktionen sind, nicht zulässig [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(849,24): error C2270: "IsTankRole": Modifizierer für Funktionen, die keine Memberfunktionen sind, nicht zulässig [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(932,21): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(893,21): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(942,59): error C3482: "this" kann nur als Lambdaerfassung innerhalb einer nicht statischen Memberfunktion verwendet werden. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(903,59): error C3482: "this" kann nur als Lambdaerfassung innerhalb einer nicht statischen Memberfunktion verwendet werden. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(944,30): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(905,30): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(944,36): error C2039: "GetGroupMembers" ist kein Member von "Playerbot::InitializeRestorationShamanMechanics::<lambda_1>". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(905,36): error C2039: "GetGroupMembers" ist kein Member von "Playerbot::InitializeRestorationShamanMechanics::<lambda_1>". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(952,13):
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(913,13):
       Siehe Deklaration von "Playerbot::InitializeRestorationShamanMechanics::<lambda_1>"
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(948,28): error C3531: "m": Ein Symbol, dessen Typ "auto" enthält, muss einen Initialisierer aufweisen. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(909,28): error C3531: "m": Ein Symbol, dessen Typ "auto" enthält, muss einen Initialisierer aufweisen. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(948,30): error C2143: Syntaxfehler: Es fehlt ";" vor ":" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(909,30): error C2143: Syntaxfehler: Es fehlt ";" vor ":" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(948,32): error C3536: "group": Kann nicht verwendet werden, bevor es initialisiert wurde. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(909,32): error C3536: "group": Kann nicht verwendet werden, bevor es initialisiert wurde. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(948,37): error C2143: Syntaxfehler: Es fehlt ";" vor ")" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(909,37): error C2143: Syntaxfehler: Es fehlt ";" vor ")" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(948,37): error C1003: Mehr als 100 Fehler gefunden; Kompilierung wird abgebrochen. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(918,67): error C3482: "this" kann nur als Lambdaerfassung innerhalb einer nicht statischen Memberfunktion verwendet werden. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
   
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(922,30): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(922,36): error C2039: "GetGroupMembers" ist kein Member von "Playerbot::InitializeRestorationShamanMechanics::<lambda_2>". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(930,13):
+      Siehe Deklaration von "Playerbot::InitializeRestorationShamanMechanics::<lambda_2>"
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(926,28): error C3531: "m": Ein Symbol, dessen Typ "auto" enthält, muss einen Initialisierer aufweisen. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(926,30): error C2143: Syntaxfehler: Es fehlt ";" vor ":" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(926,32): error C3536: "group": Kann nicht verwendet werden, bevor es initialisiert wurde. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(926,37): error C2143: Syntaxfehler: Es fehlt ";" vor ")" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(936,51): error C3482: "this" kann nur als Lambdaerfassung innerhalb einer nicht statischen Memberfunktion verwendet werden. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(938,21): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(940,30): error C2355: "this": Nur innerhalb nicht statischer Memberfunktionen verfügbar oder nicht statischer Datenmemberinitialisierer verfügbar. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(938,27): error C2039: "_ascendanceActive" ist kein Member von "Playerbot::InitializeRestorationShamanMechanics::<lambda_3>". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(948,13):
+      Siehe Deklaration von "Playerbot::InitializeRestorationShamanMechanics::<lambda_3>"
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(940,36): error C2039: "GetGroupMembers" ist kein Member von "Playerbot::InitializeRestorationShamanMechanics::<lambda_3>". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(948,13):
+      Siehe Deklaration von "Playerbot::InitializeRestorationShamanMechanics::<lambda_3>"
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(944,28): error C3531: "m": Ein Symbol, dessen Typ "auto" enthält, muss einen Initialisierer aufweisen. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(944,30): error C2143: Syntaxfehler: Es fehlt ";" vor ":" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ClassAI\Shamans\RestorationShamanRefactored.h(944,30): error C1003: Mehr als 100 Fehler gefunden; Kompilierung wird abgebrochen. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(81,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Session/BotSession.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(103,29): warning C4100: „cooldownMs“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Session/BotSession.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(164,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Session/BotSession.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Triggers\Trigger.h(83,43): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Session/BotSession.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\server\game\Server\Packets\PacketUtilities.h(75,60): error C2039: "has_type" ist kein Member von "Playerbot::Trinity". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\common\Utilities\UniqueTrackablePtr.h(23,11):
+      Siehe Deklaration von "Playerbot::Trinity"
+      C:\TrinityBots\TrinityCore\src\server\game\Server\Packets\PacketUtilities.h(75,60):
+      der Vorlageninstanziierungskontext (der älteste zuerst) ist
+          C:\TrinityBots\TrinityCore\src\server\game\Server\Packets\PacketUtilities.h(73,11):
+          beim Kompilieren der Klassenvorlage "Playerbot::WorldPackets::String"
+  
+C:\TrinityBots\TrinityCore\src\server\game\Server\Packets\PacketUtilities.h(75,60): error C2065: "has_type": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\server\game\Server\Packets\PacketUtilities.h(75,78): error C2275: "Playerbot::WorldPackets::Strings::RawBytes": Es wurde ein Ausdruck anstelle eines Typs erwartet [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\server\game\Server\Packets\PacketUtilities.h(75,36): error C2976: „std::conditional_t“: Nicht genügend Vorlage-Argumente [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\xtr1common(69,1):
+      Siehe Deklaration von "std::conditional_t"
+  
+C:\TrinityBots\TrinityCore\src\server\game\Server\Packets\PacketUtilities.h(75,116): error C2039: "value" ist kein Member von "`global namespace'". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\server\game\Server\Packets\PacketUtilities.h(75,116): error C2146: Syntaxfehler: Fehlendes ";" vor Bezeichner "value" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\server\game\Server\Packets\PacketUtilities.h(75,121): error C2059: Syntaxfehler: "," [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\server\game\Server\Packets\PacketUtilities.h(77,89): error C2238: Unerwartete(s) Token vor ";" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\server\game\Server\Packets\PacketUtilities.h(92,26): error C2027: Verwendung des undefinierten Typs "Playerbot::ByteBuffer" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\server\game\Entities\Object\Position.h(26,7):
+      Siehe Deklaration von "Playerbot::ByteBuffer"
+  
+C:\TrinityBots\TrinityCore\src\server\game\Server\Packets\PacketUtilities.h(314,57): error C2027: Verwendung des undefinierten Typs "Playerbot::ByteBuffer" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\server\game\Entities\Object\Position.h(26,7):
+      Siehe Deklaration von "Playerbot::ByteBuffer"
+      C:\TrinityBots\TrinityCore\src\server\game\Server\Packets\PacketUtilities.h(314,57):
+      der Vorlageninstanziierungskontext (der älteste zuerst) ist
+          C:\TrinityBots\TrinityCore\src\server\game\Server\Packets\PacketUtilities.h(277,11):
+          beim Kompilieren der Klassenvorlage "Playerbot::WorldPackets::Timestamp"
+  
+C:\TrinityBots\TrinityCore\src\server\game\Server\Packets\PacketUtilities.h(348,51): error C2027: Verwendung des undefinierten Typs "Playerbot::ByteBuffer" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\server\game\Entities\Object\Position.h(26,7):
+      Siehe Deklaration von "Playerbot::ByteBuffer"
+      C:\TrinityBots\TrinityCore\src\server\game\Server\Packets\PacketUtilities.h(348,51):
+      der Vorlageninstanziierungskontext (der älteste zuerst) ist
+          C:\TrinityBots\TrinityCore\src\server\game\Server\Packets\PacketUtilities.h(323,11):
+          beim Kompilieren der Klassenvorlage "Playerbot::WorldPackets::Duration"
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(66,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Session/BotSession.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(87,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Session/BotSession.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(88,38): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Session/BotSession.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,51): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Session/BotSession.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,40): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Session/BotSession.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\server\game\Server\Packets\ItemPacketsCommon.h(68,31): error C2039: "LootItem" ist kein Member von "`global namespace'". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\server\game\Server\Packets\ItemPacketsCommon.h(68,31): error C2061: Syntaxfehler: Bezeichner "LootItem" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ObjectCache.h(100,31): warning C4100: „bot“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Session/BotSession.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\server\game\Entities\Object\Updates\UpdateField.h(1068,28): error C2039: "invocable_r" ist kein Member von "Playerbot::Trinity". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\common\Utilities\UniqueTrackablePtr.h(23,11):
+      Siehe Deklaration von "Playerbot::Trinity"
+      C:\TrinityBots\TrinityCore\src\server\game\Entities\Object\Updates\UpdateField.h(1068,28):
+      der Vorlageninstanziierungskontext (der älteste zuerst) ist
+          C:\TrinityBots\TrinityCore\src\server\game\Entities\Object\Updates\UpdateField.h(1014,11):
+          beim Kompilieren der Klassenvorlage "Playerbot::UF::MapUpdateFieldBase"
+  
+C:\TrinityBots\TrinityCore\src\server\game\Entities\Object\Updates\UpdateField.h(1068,28): error C2061: Syntaxfehler: Bezeichner "invocable_r" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\server\game\Entities\Object\Updates\UpdateField.h(1068,60): error C2988: Unerkannte Vorlagendeklaration/-definition [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\server\game\Entities\Object\Updates\UpdateField.h(1068,60): error C2059: Syntaxfehler: ">" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\server\game\Entities\Object\Updates\UpdateField.h(1070,9): error C2334: Unerwartete(s) Token vor "{"; sichtbarer Funktionstext wird übersprungen [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(164,40): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Session/BotSession.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,65): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Session/BotSession.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,48): warning C4100: „spellId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Session/BotSession.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotSpawnOrchestrator.cpp(386,69): warning C4100: „request“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\server\game\Entities\Object\Updates\UpdateFields.h(1380,32): error C2027: Verwendung des undefinierten Typs "Position" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\server\game\Scripting\ScriptMgr.h(81,8):
+      Siehe Deklaration von "Position"
+  
+C:\TrinityBots\TrinityCore\src\server\game\Entities\Object\Updates\UpdateFields.h(1380,32): error C2065: "XYZ": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\server\game\Entities\Object\Updates\UpdateFields.h(1380,5): error C2923: „Playerbot::TaggedPosition“: „XYZ“ ist kein gültiges Vorlage-Typargument für Parameter „Tag“. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\server\game\Entities\Object\Updates\UpdateFields.h(1380,32):
+      Siehe Deklaration von "XYZ"
+  
+C:\TrinityBots\TrinityCore\src\server\game\Entities\Object\Updates\UpdateFields.h(1380,37): error C2955: "Playerbot::TaggedPosition" : Für die Verwendung von Klasse Vorlage ist eine Vorlage-Argumentliste erforderlich [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\server\game\Entities\Object\Position.h(231,8):
+      Siehe Deklaration von "Playerbot::TaggedPosition"
+  
+C:\TrinityBots\TrinityCore\src\server\game\Combat\ThreatManager.h(124,18): error C2039: "IteratorPair" ist kein Member von "Playerbot::Trinity". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\server\game\Entities\Object\Object.h(1011,11):
+      Siehe Deklaration von "Playerbot::Trinity"
+  
+C:\TrinityBots\TrinityCore\src\server\game\Combat\ThreatManager.h(124,18): error C7568: Nach der angenommenen Funktionsvorlage "IteratorPair" fehlt die Argumentliste. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\server\game\Combat\ThreatManager.h(124,18): error C2062: "<error type>"-Typ unerwartet [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\server\game\Combat\ThreatManager.h(124,96): error C2238: Unerwartete(s) Token vor ";" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\server\game\Combat\ThreatManager.h(128,18): error C2039: "IteratorPair" ist kein Member von "Playerbot::Trinity". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\server\game\Entities\Object\Object.h(1011,11):
+      Siehe Deklaration von "Playerbot::Trinity"
+  
+C:\TrinityBots\TrinityCore\src\server\game\Combat\ThreatManager.h(128,18): error C7568: Nach der angenommenen Funktionsvorlage "IteratorPair" fehlt die Argumentliste. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\server\game\Combat\ThreatManager.h(128,18): error C2062: "<error type>"-Typ unerwartet [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\server\game\Combat\ThreatManager.h(128,94): error C2238: Unerwartete(s) Token vor ";" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\server\game\Entities\Unit\UnitDefines.h(356,53): error C2440: "Initialisierung": "unsigned int" kann nicht in "const Playerbot::NPCFlags" konvertiert werden [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\server\game\Entities\Unit\UnitDefines.h(356,53):
+      Die Konvertierung in einen Enumerationstypen erfordert explizite Umwandlung (static_cast-Umwandlung, C-Stil-Umwandlung oder eine in Klammern gesetzte Umwandlung im Funktionsstil)
+  
+C:\TrinityBots\TrinityCore\src\server\game\Entities\Unit\UnitDefines.h(356,53): error C2131: Ausdruck wurde nicht zu einer Konstanten ausgewertet. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+      C:\TrinityBots\TrinityCore\src\server\game\Entities\Unit\UnitDefines.h(356,53):
+      Ein nicht konstanter (Teil)ausdruck wurde gefunden.
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(55,41): error C7568: Nach der angenommenen Funktionsvorlage "uses_allocator_v" fehlt die Argumentliste. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(55,41):
+      der Vorlageninstanziierungskontext (der älteste zuerst) ist
+          C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(27,7):
+          beim Kompilieren der Klassenvorlage "Playerbot::std::stack"
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(55,29): error C7568: Nach der angenommenen Funktionsvorlage "enable_if_t" fehlt die Argumentliste. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(55,29): error C2993: "<error type>": Kein gültiger Typ für den Nichttyp-Vorlagenparameter "__formal". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(59,41): error C7568: Nach der angenommenen Funktionsvorlage "uses_allocator_v" fehlt die Argumentliste. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(59,29): error C7568: Nach der angenommenen Funktionsvorlage "enable_if_t" fehlt die Argumentliste. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(59,29): error C2993: "<error type>": Kein gültiger Typ für den Nichttyp-Vorlagenparameter "__formal". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(62,41): error C7568: Nach der angenommenen Funktionsvorlage "uses_allocator_v" fehlt die Argumentliste. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(62,29): error C7568: Nach der angenommenen Funktionsvorlage "enable_if_t" fehlt die Argumentliste. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(62,29): error C2993: "<error type>": Kein gültiger Typ für den Nichttyp-Vorlagenparameter "__formal". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(67,41): error C7568: Nach der angenommenen Funktionsvorlage "uses_allocator_v" fehlt die Argumentliste. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(67,29): error C7568: Nach der angenommenen Funktionsvorlage "enable_if_t" fehlt die Argumentliste. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(67,29): error C2993: "<error type>": Kein gültiger Typ für den Nichttyp-Vorlagenparameter "__formal". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(70,41): error C7568: Nach der angenommenen Funktionsvorlage "uses_allocator_v" fehlt die Argumentliste. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(70,29): error C7568: Nach der angenommenen Funktionsvorlage "enable_if_t" fehlt die Argumentliste. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(70,29): error C2993: "<error type>": Kein gültiger Typ für den Nichttyp-Vorlagenparameter "__formal". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(149,69): error C2653: "_Is_allocator": Keine Klasse oder Namespace [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(149,42): error C2903: "_Is_allocator": Symbol ist weder eine Klassen-Vorlage noch eine Funktions-Vorlage. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(149,69): error C2065: "value": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(149,29): error C7568: Nach der angenommenen Funktionsvorlage "enable_if_t" fehlt die Argumentliste. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(149,29): error C2993: "<error type>": Kein gültiger Typ für den Nichttyp-Vorlagenparameter "__formal". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(153,40): error C7568: Nach der angenommenen Funktionsvorlage "_Is_allocator" fehlt die Argumentliste. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(153,31): error C7568: Nach der angenommenen Funktionsvorlage "negation" fehlt die Argumentliste. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(153,68): error C7568: Nach der angenommenen Funktionsvorlage "uses_allocator" fehlt die Argumentliste. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(153,17): error C7568: Nach der angenommenen Funktionsvorlage "conjunction_v" fehlt die Argumentliste. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(153,5): error C7568: Nach der angenommenen Funktionsvorlage "enable_if_t" fehlt die Argumentliste. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(153,5): error C2993: "<error type>": Kein gültiger Typ für den Nichttyp-Vorlagenparameter "__formal". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(199,34): error C2061: Syntaxfehler: Bezeichner "three_way_comparable" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(200,39): error C2065: "_Container": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(200,12): error C7568: Nach der angenommenen Funktionsvorlage "compare_three_way_result_t" fehlt die Argumentliste. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(201,22): error C2065: "_Container": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(201,11): error C2923: „Playerbot::std::stack“: „_Container“ ist kein gültiges Vorlage-Typargument für Parameter „_Container“. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(201,22):
+      Siehe Deklaration von "_Container"
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(201,35): error C2955: "Playerbot::std::stack" : Für die Verwendung von Klasse Vorlage ist eine Vorlage-Argumentliste erforderlich [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(27,7):
+      Siehe Deklaration von "Playerbot::std::stack"
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(201,59): error C2065: "_Container": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(201,48): error C2923: „Playerbot::std::stack“: „_Container“ ist kein gültiges Vorlage-Typargument für Parameter „_Container“. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(201,59):
+      Siehe Deklaration von "_Container"
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(201,72): error C2955: "Playerbot::std::stack" : Für die Verwendung von Klasse Vorlage ist eine Vorlage-Argumentliste erforderlich [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(27,7):
+      Siehe Deklaration von "Playerbot::std::stack"
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(206,91): error C2653: "_Is_swappable": Keine Klasse oder Namespace [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(206,64): error C2903: "_Is_swappable": Symbol ist weder eine Klassen-Vorlage noch eine Funktions-Vorlage. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(206,91): error C2065: "value": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(206,52): error C7568: Nach der angenommenen Funktionsvorlage "enable_if_t" fehlt die Argumentliste. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(206,52): error C2993: "<error type>": Kein gültiger Typ für den Nichttyp-Vorlagenparameter "__formal". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(212,22): error C3856: "uses_allocator": Symbol ist keine Klasse "Vorlage". [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(212,29): error C2065: "_Ty": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(212,34): error C2065: "_Container": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(212,23): error C2923: „Playerbot::std::stack“: „_Ty“ ist kein gültiges Vorlage-Typargument für Parameter „_Ty“. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(212,29):
+      Siehe Deklaration von "_Ty"
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(212,23): error C2923: „Playerbot::std::stack“: „_Container“ ist kein gültiges Vorlage-Typargument für Parameter „_Container“. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(212,34):
+      Siehe Deklaration von "_Container"
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(212,23): error C2146: Syntaxfehler: Fehlendes ";" vor Bezeichner "stack" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(212,45): error C2059: Syntaxfehler: "," [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(212,72): error C2065: "_Container": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(212,84): error C2065: "_Alloc": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(212,57): error C2923: „Playerbot::std::uses_allocator“: „_Container“ ist kein gültiges Vorlage-Typargument für Parameter „_Ty“. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(212,72):
+      Siehe Deklaration von "_Container"
+  
+C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\stack(212,57): error C1003: Mehr als 100 Fehler gefunden; Kompilierung wird abgebrochen. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Scripts/PlayerbotWorldScript.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(57,12): warning C4189: "botGuid": Lokale Variable ist initialisiert aber nicht referenziert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(108,29): error C2838: "REPUTATION_FOCUSED": Unzulässiger qualifizierter Name in der Memberdeklaration. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(108,29): error C2065: "REPUTATION_FOCUSED": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(108,29): error C2131: Ausdruck wurde nicht zu einer Konstanten ausgewertet. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(108,29):
+      Ein nicht konstanter (Teil)ausdruck wurde gefunden.
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(108,29): error C2051: case-Ausdruck ist keine Konstante [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(1041,26): warning C4018: ">=": Konflikt zwischen "signed" und "unsigned" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(166,74): warning C4100: „situation“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(210,92): warning C4100: „situation“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1085,50): error C2027: Verwendung des undefinierten Typs "bot::ai::DecisionVote" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.h(29,12):
+      Siehe Deklaration von "bot::ai::DecisionVote"
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1085,50): error C2079: "Playerbot::AdaptiveBehaviorManager::GetRecommendedAction" verwendet undefiniertes struct "bot::ai::DecisionVote" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1090,35): error C2027: Verwendung des undefinierten Typs "bot::ai::DecisionVote" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.h(29,12):
+      Siehe Deklaration von "bot::ai::DecisionVote"
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1170,9): error C2065: "vote": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1172,9): error C2065: "vote": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1174,9): error C2065: "vote": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1176,9): error C2065: "vote": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1184,13): error C2065: "primaryRole": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1184,13): error C2050: Switch-Ausdruck ist keine Ganzzahl [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1186,23): error C2440: "Typumwandlung": "Playerbot::BotRole" kann nicht in "int" konvertiert werden [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1186,23):
+      Diese Konvertierung erfordert eine explizite Umwandlung (static_cast-Umwandlung, C-Stil-Umwandlung oder eine in Klammern gesetzte Umwandlung im Funktionsstil)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1186,9): error C2046: Schlüsselwort "case" ungültig [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1187,23): error C2440: "Typumwandlung": "Playerbot::BotRole" kann nicht in "int" konvertiert werden [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1187,23):
+      Diese Konvertierung erfordert eine explizite Umwandlung (static_cast-Umwandlung, C-Stil-Umwandlung oder eine in Klammern gesetzte Umwandlung im Funktionsstil)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1187,9): error C2046: Schlüsselwort "case" ungültig [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1198,17): error C2065: "vote": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1201,23): error C2440: "Typumwandlung": "Playerbot::BotRole" kann nicht in "int" konvertiert werden [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1201,23):
+      Diese Konvertierung erfordert eine explizite Umwandlung (static_cast-Umwandlung, C-Stil-Umwandlung oder eine in Klammern gesetzte Umwandlung im Funktionsstil)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1201,9): error C2046: Schlüsselwort "case" ungültig [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1202,23): error C2440: "Typumwandlung": "Playerbot::BotRole" kann nicht in "int" konvertiert werden [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1202,23):
+      Diese Konvertierung erfordert eine explizite Umwandlung (static_cast-Umwandlung, C-Stil-Umwandlung oder eine in Klammern gesetzte Umwandlung im Funktionsstil)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1202,9): error C2046: Schlüsselwort "case" ungültig [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1213,21): error C2065: "vote": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1218,21): error C2065: "vote": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1227,23): error C2440: "Typumwandlung": "Playerbot::BotRole" kann nicht in "int" konvertiert werden [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1227,23):
+      Diese Konvertierung erfordert eine explizite Umwandlung (static_cast-Umwandlung, C-Stil-Umwandlung oder eine in Klammern gesetzte Umwandlung im Funktionsstil)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1227,9): error C2046: Schlüsselwort "case" ungültig [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1236,17): error C2065: "vote": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1242,23): error C2440: "Typumwandlung": "Playerbot::BotRole" kann nicht in "int" konvertiert werden [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1242,23):
+      Diese Konvertierung erfordert eine explizite Umwandlung (static_cast-Umwandlung, C-Stil-Umwandlung oder eine in Klammern gesetzte Umwandlung im Funktionsstil)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1242,9): error C2046: Schlüsselwort "case" ungültig [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1251,17): error C2065: "vote": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1257,23): error C2440: "Typumwandlung": "Playerbot::BotRole" kann nicht in "int" konvertiert werden [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1257,23):
+      Diese Konvertierung erfordert eine explizite Umwandlung (static_cast-Umwandlung, C-Stil-Umwandlung oder eine in Klammern gesetzte Umwandlung im Funktionsstil)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1257,9): error C2046: Schlüsselwort "case" ungültig [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1262,17): error C2065: "vote": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1268,23): error C2440: "Typumwandlung": "Playerbot::BotRole" kann nicht in "int" konvertiert werden [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1268,23):
+      Diese Konvertierung erfordert eine explizite Umwandlung (static_cast-Umwandlung, C-Stil-Umwandlung oder eine in Klammern gesetzte Umwandlung im Funktionsstil)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1268,9): error C2046: Schlüsselwort "case" ungültig [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1276,23): error C2440: "Typumwandlung": "Playerbot::BotRole" kann nicht in "int" konvertiert werden [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+      C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1276,23):
+      Diese Konvertierung erfordert eine explizite Umwandlung (static_cast-Umwandlung, C-Stil-Umwandlung oder eine in Klammern gesetzte Umwandlung im Funktionsstil)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1276,9): error C2046: Schlüsselwort "case" ungültig [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1289,13): error C2065: "vote": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1298,5): error C2065: "vote": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1298,38): error C2065: "vote": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1298,34): error C2672: "std::max": keine übereinstimmende überladene Funktion gefunden [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\utility(85,26):
+      kann "_Ty std::max(std::initializer_list<_Elem>)" sein
+          C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1298,34):
+          „_Ty std::max(std::initializer_list<_Elem>)“ erwartet, dass 1 Argumente – 2 angegeben werden.
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\utility(82,26):
+      oder "_Ty std::max(std::initializer_list<_Elem>,_Pr)"
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\utility(74,6):
+      oder "const _Ty &std::max(const _Ty &,const _Ty &) noexcept(<expr>)"
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\utility(64,33):
+      oder "const _Ty &std::max(const _Ty &,const _Ty &,_Pr) noexcept(<expr>)"
+          C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1298,34):
+          „const _Ty &std::max(const _Ty &,const _Ty &,_Pr) noexcept(<expr>)“ erwartet, dass 3 Argumente – 2 angegeben werden.
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1298,25): error C2672: "std::min": keine übereinstimmende überladene Funktion gefunden [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\utility(109,26):
+      kann "_Ty std::min(std::initializer_list<_Elem>)" sein
+          C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1298,25):
+          „_Ty std::min(std::initializer_list<_Elem>)“ erwartet, dass 1 Argumente – 2 angegeben werden.
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\utility(106,26):
+      oder "_Ty std::min(std::initializer_list<_Elem>,_Pr)"
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\utility(98,6):
+      oder "const _Ty &std::min(const _Ty &,const _Ty &) noexcept(<expr>)"
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\utility(88,33):
+      oder "const _Ty &std::min(const _Ty &,const _Ty &,_Pr) noexcept(<expr>)"
+          C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1298,25):
+          „const _Ty &std::min(const _Ty &,const _Ty &,_Pr) noexcept(<expr>)“ erwartet, dass 3 Argumente – 2 angegeben werden.
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1300,5): error C2065: "vote": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1310,12): error C2065: "vote": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1311,5): warning C4138: "*/" wurde außerhalb des Kommentars gefunden [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1311,6): error C2059: Syntaxfehler: "/" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\AdaptiveBehaviorManager.cpp(1291,5): warning C4065: switch-Anweisung enthält "default", aber keine case-Bezeichnungen [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(66,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Quest/QuestCompletion.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(87,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Quest/QuestCompletion.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(88,38): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Quest/QuestCompletion.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,51): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Quest/QuestCompletion.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,40): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Quest/QuestCompletion.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(81,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Quest/QuestCompletion.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(103,29): warning C4100: „cooldownMs“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Quest/QuestCompletion.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(164,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Quest/QuestCompletion.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Triggers\Trigger.h(83,43): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Quest/QuestCompletion.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ObjectCache.h(100,31): warning C4100: „bot“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Quest/QuestCompletion.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Core\Events\BotEventTypes.h(178,57): warning C4100: „event“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/PlayerbotModule.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\CombatBehaviorIntegration.cpp(155,30): warning C4189: "metrics": Lokale Variable ist initialisiert aber nicht referenziert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Combat\CombatBehaviorIntegration.cpp(471,56): warning C4018: "<": Konflikt zwischen "signed" und "unsigned" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(164,40): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/Quest/QuestCompletion.cpp“ wird kompiliert)
   
@@ -2025,6 +2732,41 @@ C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,65): warning C41
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,48): warning C4100: „spellId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
   (Quelldatei „../../../../src/modules/Playerbot/Quest/QuestCompletion.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotSpawner.h(183,25): warning C4099: "std::default_delete<Playerbot::BotSpawner>": Geben Sie den zuerst unter Verwendung von "struct" und jetzt unter Verwendung von "class" gesehenen Namen ein [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Session/BotSession.cpp“ wird kompiliert)
+      C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.44.35207\include\memory(3301,8):
+      Siehe Deklaration von "std::default_delete<Playerbot::BotSpawner>"
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(81,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Quest/QuestTurnIn.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(103,29): warning C4100: „cooldownMs“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Quest/QuestTurnIn.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Actions\Action.h(164,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Quest/QuestTurnIn.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Triggers\Trigger.h(83,43): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Quest/QuestTurnIn.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Core\Events\BotEventTypes.h(178,57): warning C4100: „event“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Session/BotSession.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(66,34): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Quest/QuestTurnIn.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(87,36): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Quest/QuestTurnIn.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(88,38): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Quest/QuestTurnIn.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,51): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Quest/QuestTurnIn.cpp“ wird kompiliert)
+  
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\Strategy\Strategy.h(94,40): warning C4100: „ai“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Quest/QuestTurnIn.cpp“ wird kompiliert)
   
 C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\QuestCompletion.cpp(1480,9): error C2440: "return": "Playerbot::QuestCompletion::QuestCompletionMetrics::Snapshot" kann nicht in "Playerbot::IQuestCompletion::QuestCompletionMetricsSnapshot" konvertiert werden [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
       C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\QuestCompletion.cpp(1480,9):
@@ -2038,93 +2780,35 @@ C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\QuestCompletion.cpp(1492,
       C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\QuestCompletion.cpp(1492,5):
       Kein benutzerdefinierter Konvertierungsoperator verfügbar, der diese Konvertierung durchführen kann, oder der Operator kann nicht aufgerufen werden
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(90,29): error C2027: Verwendung des undefinierten Typs "Playerbot::QuestStrategy" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Core\DI\Interfaces\IDynamicQuestSystem.h(27,12):
-      Siehe Deklaration von "Playerbot::QuestStrategy"
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\ObjectCache.h(100,31): warning C4100: „bot“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Quest/QuestTurnIn.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(90,29): error C2065: "SOLO_FOCUSED": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(90,29): error C2131: Ausdruck wurde nicht zu einer Konstanten ausgewertet. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(90,29):
-      Ein nicht konstanter (Teil)ausdruck wurde gefunden.
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(164,40): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Quest/QuestTurnIn.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(93,29): error C2027: Verwendung des undefinierten Typs "Playerbot::QuestStrategy" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Core\DI\Interfaces\IDynamicQuestSystem.h(27,12):
-      Siehe Deklaration von "Playerbot::QuestStrategy"
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,65): warning C4100: „target“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Quest/QuestTurnIn.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(93,29): error C2065: "GROUP_PREFERRED": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(93,29): error C2131: Ausdruck wurde nicht zu einer Konstanten ausgewertet. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(93,29):
-      Ein nicht konstanter (Teil)ausdruck wurde gefunden.
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\AI\BotAI.h(249,48): warning C4100: „spellId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+  (Quelldatei „../../../../src/modules/Playerbot/Quest/QuestTurnIn.cpp“ wird kompiliert)
   
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(96,29): error C2027: Verwendung des undefinierten Typs "Playerbot::QuestStrategy" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Core\DI\Interfaces\IDynamicQuestSystem.h(27,12):
-      Siehe Deklaration von "Playerbot::QuestStrategy"
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(96,29): error C2065: "ZONE_OPTIMIZATION": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(96,29): error C2131: Ausdruck wurde nicht zu einer Konstanten ausgewertet. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(96,29):
-      Ein nicht konstanter (Teil)ausdruck wurde gefunden.
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(99,29): error C2027: Verwendung des undefinierten Typs "Playerbot::QuestStrategy" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Core\DI\Interfaces\IDynamicQuestSystem.h(27,12):
-      Siehe Deklaration von "Playerbot::QuestStrategy"
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(99,29): error C2065: "LEVEL_PROGRESSION": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(99,29): error C2131: Ausdruck wurde nicht zu einer Konstanten ausgewertet. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(99,29):
-      Ein nicht konstanter (Teil)ausdruck wurde gefunden.
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(102,29): error C2027: Verwendung des undefinierten Typs "Playerbot::QuestStrategy" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Core\DI\Interfaces\IDynamicQuestSystem.h(27,12):
-      Siehe Deklaration von "Playerbot::QuestStrategy"
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(102,29): error C2065: "GEAR_PROGRESSION": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(102,29): error C2131: Ausdruck wurde nicht zu einer Konstanten ausgewertet. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(102,29):
-      Ein nicht konstanter (Teil)ausdruck wurde gefunden.
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(105,29): error C2027: Verwendung des undefinierten Typs "Playerbot::QuestStrategy" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Core\DI\Interfaces\IDynamicQuestSystem.h(27,12):
-      Siehe Deklaration von "Playerbot::QuestStrategy"
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(105,29): error C2065: "STORY_PROGRESSION": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(105,29): error C2131: Ausdruck wurde nicht zu einer Konstanten ausgewertet. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(105,29):
-      Ein nicht konstanter (Teil)ausdruck wurde gefunden.
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(108,29): error C2027: Verwendung des undefinierten Typs "Playerbot::QuestStrategy" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Core\DI\Interfaces\IDynamicQuestSystem.h(27,12):
-      Siehe Deklaration von "Playerbot::QuestStrategy"
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(108,29): error C2065: "REPUTATION_FOCUSED": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(108,29): error C2131: Ausdruck wurde nicht zu einer Konstanten ausgewertet. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(108,29):
-      Ein nicht konstanter (Teil)ausdruck wurde gefunden.
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(90,29): error C2051: case-Ausdruck ist keine Konstante [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(93,29): error C2051: case-Ausdruck ist keine Konstante [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(96,29): error C2051: case-Ausdruck ist keine Konstante [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(99,29): error C2051: case-Ausdruck ist keine Konstante [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(102,29): error C2051: case-Ausdruck ist keine Konstante [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(105,29): error C2051: case-Ausdruck ist keine Konstante [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(108,29): error C2051: case-Ausdruck ist keine Konstante [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(114,5): warning C4065: switch-Anweisung enthält "default", aber keine case-Bezeichnungen [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(838,27): error C2027: Verwendung des undefinierten Typs "Playerbot::QuestStrategy" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-      C:\TrinityBots\TrinityCore\src\modules\Playerbot\Core\DI\Interfaces\IDynamicQuestSystem.h(27,12):
-      Siehe Deklaration von "Playerbot::QuestStrategy"
-  
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(838,27): error C2065: "LEVEL_PROGRESSION": nichtdeklarierter Bezeichner [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\DynamicQuestSystem.cpp(1041,26): warning C4018: ">=": Konflikt zwischen "signed" und "unsigned" [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\ObjectiveTracker.cpp(123,68): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\ObjectiveTracker.cpp(292,81): warning C4100: „itemId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\ObjectiveTracker.cpp(510,68): warning C4100: „questId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\ObjectiveTracker.cpp(555,54): warning C4100: „targetId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\ObjectiveTracker.cpp(617,65): warning C4100: „radius“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\ObjectiveTracker.cpp(714,74): warning C4100: „questId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\ObjectiveTracker.cpp(812,12): warning C4189: "botGuid": Lokale Variable ist initialisiert aber nicht referenziert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\ObjectiveTracker.cpp(1148,92): warning C4100: „questId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\ObjectiveTracker.cpp(1199,86): warning C4100: „state“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
-C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\ObjectiveTracker.cpp(1220,38): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\QuestTurnIn.cpp(66,18): warning C4189: "quest": Lokale Variable ist initialisiert aber nicht referenziert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\QuestTurnIn.cpp(1005,33): warning C4100: „diff“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\QuestTurnIn.cpp(1221,101): warning C4100: „bot“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Session\BotSession.cpp(546,52): warning C4100: „updater“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Session\BotSession.cpp(655,16): warning C4189: "currentTime": Lokale Variable ist initialisiert aber nicht referenziert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Quest\QuestTurnIn.cpp(1277,107): warning C4100: „bot“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Session\BotSession.cpp(1632,14): warning C4189: "isLocalRealm": Lokale Variable ist initialisiert aber nicht referenziert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Session\BotSession.cpp(1617,14): warning C4189: "allowMultipleRoles": Lokale Variable ist initialisiert aber nicht referenziert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Session\BotSession.cpp(1620,14): warning C4189: "isCrossFaction": Lokale Variable ist initialisiert aber nicht referenziert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Session\BotSession.cpp(1616,14): warning C4189: "shouldSquelch": Lokale Variable ist initialisiert aber nicht referenziert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Session\BotSession.cpp(1615,14): warning C4189: "isXNativeRealm": Lokale Variable ist initialisiert aber nicht referenziert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Session\BotSession.cpp(1633,14): warning C4189: "isInternalRealm": Lokale Variable ist initialisiert aber nicht referenziert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Session\BotSession.cpp(1618,14): warning C4189: "questSessionActive": Lokale Variable ist initialisiert aber nicht referenziert [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotSpawner.cpp(1227,61): warning C4100: „mapId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotSpawner.cpp(1276,65): warning C4100: „mapId“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotSpawner.cpp(1538,88): warning C4100: „request“: nicht referenzierter Parameter [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
+C:\TrinityBots\TrinityCore\src\modules\Playerbot\Lifecycle\BotSpawner.cpp(629,1): warning C4715: "`Playerbot::BotSpawner::SpawnBotInternal'::`9'::<lambda_1>::operator()": Nicht alle Codepfade geben einen Wert zurück. [c:\TrinityBots\TrinityCore\build\src\server\modules\Playerbot\playerbot.vcxproj]
 
 ========================================
 ERROR: Build failed!

--- a/src/modules/Playerbot/Lifecycle/BotLifecycleMgr.h
+++ b/src/modules/Playerbot/Lifecycle/BotLifecycleMgr.h
@@ -129,7 +129,7 @@ private:
 
     // Event processing (TBB removed - using std:: equivalents)
     std::queue<LifecycleEventInfo> _eventQueue;
-    mutable Playerbot::OrderedRecursiveMutex<Playerbot::LockOrder::BOT_SPAWNER> _eventQueueMutex;
+    mutable OrderedRecursiveMutex<LockOrder::BOT_SPAWNER> _eventQueueMutex;
 
     // Thread management
     std::unique_ptr<std::thread> _workerThread;
@@ -155,7 +155,7 @@ private:
 
     std::vector<EventSubscription> _eventHandlers;
     std::atomic<uint32> _nextHandlerId{1};
-    mutable Playerbot::OrderedRecursiveMutex<Playerbot::LockOrder::BOT_SPAWNER> _handlersMutex;
+    mutable OrderedRecursiveMutex<LockOrder::BOT_SPAWNER> _handlersMutex;
 
     // Internal processing
     void WorkerThreadProc();
@@ -194,7 +194,7 @@ private:
     // Correlation tracking
     std::string GenerateCorrelationId();
     std::unordered_map<std::string, std::vector<LifecycleEventInfo>> _correlatedEvents;
-    mutable Playerbot::OrderedRecursiveMutex<Playerbot::LockOrder::BOT_SPAWNER> _correlationMutex;
+    mutable OrderedRecursiveMutex<LockOrder::BOT_SPAWNER> _correlationMutex;
 };
 
 // Lifecycle event logging macros

--- a/src/modules/Playerbot/Lifecycle/BotPopulationManager.h
+++ b/src/modules/Playerbot/Lifecycle/BotPopulationManager.h
@@ -111,7 +111,7 @@ private:
     ::std::atomic<uint32> _totalPlayerCount{0};
 
     // Zone population tracking (requires synchronization)
-    mutable Playerbot::OrderedRecursiveMutex<Playerbot::LockOrder::BOT_SPAWNER> _populationMutex;
+    mutable OrderedRecursiveMutex<LockOrder::BOT_SPAWNER> _populationMutex;
     ::std::unordered_map<uint32, ZonePopulation> _zonePopulations; // zoneId -> population data
     ::std::unordered_map<uint32, ::std::vector<ObjectGuid>> _botsByZone; // zoneId -> bot guids
 
@@ -131,7 +131,7 @@ private:
         bool isValid = false;
     };
     mutable PopulationCache _cache;
-    mutable Playerbot::OrderedRecursiveMutex<Playerbot::LockOrder::BOT_SPAWNER> _cacheMutex;
+    mutable OrderedRecursiveMutex<LockOrder::BOT_SPAWNER> _cacheMutex;
 
     // Timing
     ::std::chrono::steady_clock::time_point _lastUpdate;

--- a/src/modules/Playerbot/Lifecycle/BotScheduler.h
+++ b/src/modules/Playerbot/Lifecycle/BotScheduler.h
@@ -266,16 +266,16 @@ private:
     SchedulerStats _stats;
 
     // Thread-safe activity pattern storage
-    mutable Playerbot::OrderedRecursiveMutex<Playerbot::LockOrder::BOT_SPAWNER> _patternMutex;
+    mutable OrderedRecursiveMutex<LockOrder::BOT_SPAWNER> _patternMutex;
     ::std::unordered_map<::std::string, ActivityPattern> _activityPatterns;
 
     // Thread-safe bot schedule state storage (TBB removed)
-    mutable Playerbot::OrderedRecursiveMutex<Playerbot::LockOrder::BOT_SPAWNER> _scheduleMutex;
+    mutable OrderedRecursiveMutex<LockOrder::BOT_SPAWNER> _scheduleMutex;
     ::std::unordered_map<ObjectGuid, BotScheduleState> _botSchedules;
 
     // Priority queue for scheduled actions (TBB removed)
     ::std::priority_queue<ScheduleEntry> _scheduleQueue;
-    mutable Playerbot::OrderedRecursiveMutex<Playerbot::LockOrder::BOT_SPAWNER> _scheduleQueueMutex;
+    mutable OrderedRecursiveMutex<LockOrder::BOT_SPAWNER> _scheduleQueueMutex;
 
     // Runtime state
     ::std::atomic<bool> _enabled{true};


### PR DESCRIPTION
…rbot::)

Fixed critical namespace pollution causing 377 compilation errors.

ROOT CAUSE:
Inside 'namespace Playerbot {}', code was using 'Playerbot::OrderedRecursiveMutex' which caused compiler to look for 'Playerbot::Playerbot::OrderedRecursiveMutex'. This triggered cascading namespace pollution into std:: causing massive errors.

FIXES:
1. BotScheduler.h (lines 269, 273, 278):
   - Changed: Playerbot::OrderedRecursiveMutex<Playerbot::LockOrder::BOT_SPAWNER>
   - To: OrderedRecursiveMutex<LockOrder::BOT_SPAWNER>

2. BotPopulationManager.h (lines 114, 134):
   - Changed: Playerbot::OrderedRecursiveMutex<Playerbot::LockOrder::BOT_SPAWNER>
   - To: OrderedRecursiveMutex<LockOrder::BOT_SPAWNER>

3. BotLifecycleMgr.h (lines 132, 158, 197):
   - Changed: Playerbot::OrderedRecursiveMutex<Playerbot::LockOrder::BOT_SPAWNER>
   - To: OrderedRecursiveMutex<LockOrder::BOT_SPAWNER>

IMPACT:
This should resolve ~200+ cascading namespace errors including:
- C2039: OrderedRecursiveMutex not a member of Playerbot::Playerbot
- C2059: Syntax errors from namespace pollution
- C2065: Undeclared identifiers in std:: namespace
- C7568: Template argument list errors
- Multiple std::pmr and STL template resolution failures

Expected reduction: 377 errors → ~100-150 errors remaining