### PR TITLE
fix(playerbot): PHASE 110 - Move member variables before inline funct…

### DIFF
--- a/src/modules/Playerbot/AI/ClassAI/Shamans/RestorationShamanRefactored.h
+++ b/src/modules/Playerbot/AI/ClassAI/Shamans/RestorationShamanRefactored.h
@@ -364,7 +364,20 @@ public:
     }
 
 private:
-    
+    // Member variables
+    RiptideTracker _riptideTracker;
+    EarthShieldTracker _earthShieldTracker;
+
+    bool _ascendanceActive;
+    uint32 _ascendanceEndTime;
+
+    uint32 _lastAscendanceTime;
+    uint32 _lastHealingTideTotemTime;
+    uint32 _lastSpiritLinkTotemTime;
+    uint32 _lastCloudburstTotemTime;
+    uint32 _lastEarthenWallTotemTime;
+    uint32 _lastAncestralProtectionTotemTime;
+    CooldownManager _cooldowns;
 
     void UpdateRestorationState()
     {
@@ -867,21 +880,6 @@ private:
 
         return false;
     }
-
-    // Member variables
-    RiptideTracker _riptideTracker;
-    EarthShieldTracker _earthShieldTracker;
-
-    bool _ascendanceActive;
-    uint32 _ascendanceEndTime;
-
-    uint32 _lastAscendanceTime;
-    uint32 _lastHealingTideTotemTime;
-    uint32 _lastSpiritLinkTotemTime;
-    uint32 _lastCloudburstTotemTime;
-    uint32 _lastEarthenWallTotemTime;
-    uint32 _lastAncestralProtectionTotemTime;
-    CooldownManager _cooldowns;
 
     // ========================================================================
     // PHASE 5: DECISION SYSTEM INTEGRATION


### PR DESCRIPTION
…ions

- Moved member variable declarations (_riptideTracker, _earthShieldTracker, etc.) to immediately after private: label (line 366)
- Previously declared at line 872 AFTER inline function definitions
- MSVC C2614 error: compiler couldn't recognize members when declared after inline functions
- Fixes ~30 RestorationShamanRefactored compilation errors
- Conventional C++ style: declare all members before inline function definitions