### PR TITLE
fix(playerbot): PHASE 111 - Fix malformed if statements and brace pla…

### DIFF
--- a/src/modules/Playerbot/AI/ClassAI/Shamans/RestorationShamanRefactored.h
+++ b/src/modules/Playerbot/AI/ClassAI/Shamans/RestorationShamanRefactored.h
@@ -255,15 +255,14 @@ public:
 
     void UpdateRotation(::Unit* target) override
     {
-        Player* bot = this->GetBot();        if (!target || !bot)
-
+        Player* bot = this->GetBot();
+        if (!target || !bot)
             return;
 
         UpdateRestorationState();
 
         // Restoration is a healer - check group health first
         if (Group* group = bot->GetGroup())
-        
         {
 
             ::std::vector<Unit*> groupMembers;
@@ -439,8 +438,8 @@ private:
 
     bool HandleEmergencyCooldowns(const ::std::vector<Unit*>& group)
     {
-        Player* bot = this->GetBot();        if (!bot)
-
+        Player* bot = this->GetBot();
+        if (!bot)
             return false;
 
         // Ancestral Protection Totem (resurrect on death)
@@ -502,7 +501,8 @@ private:
         }
 
         // Spirit Link Totem (equalize health)
-        if (lowHealthCount >= 3 && (GameTime::GetGameTimeMS() - _lastSpiritLinkTotemTime) >= 180000) // 3 min CD        {
+        if (lowHealthCount >= 3 && (GameTime::GetGameTimeMS() - _lastSpiritLinkTotemTime) >= 180000) // 3 min CD
+        {
 
             if (this->CanCastSpell(REST_SPIRIT_LINK_TOTEM, bot))
 


### PR DESCRIPTION
…cement

- Line 258: Split 'Player* bot = GetBot();' and 'if (\!target || \!bot)' onto separate lines
- Line 265-266: Removed extra blank line between 'if (Group* group...)' and opening brace
- Line 442: Split 'Player* bot = GetBot();' and 'if (\!bot)' onto separate lines
- Line 505: Moved opening brace from end of comment line to next line

These formatting issues caused MSVC C2059 'Syntaxfehler: if' errors All subsequent code was not properly scoped within functions Fixes ~30 RestorationShamanRefactored compilation errors