### PR TITLE
fix(playerbot): PHASE 113 amendment - Convert static constexpr to #de…

### DIFF
--- a/src/modules/Playerbot/AI/Combat/MovementIntegration.cpp
+++ b/src/modules/Playerbot/AI/Combat/MovementIntegration.cpp
@@ -15,10 +15,8 @@
 namespace Playerbot
 {
 
-// REMOVED: Static constant definitions (now constexpr in header)
-// const float MovementIntegration::MELEE_RANGE = 5.0f;
-// const float MovementIntegration::RANGED_OPTIMAL = 35.0f;
-// const float MovementIntegration::KITING_DISTANCE = 15.0f;
+// REMOVED: Static constant definitions (now #define in header)
+// See MovementIntegration.h for MOVEMENT_MELEE_RANGE, MOVEMENT_RANGED_OPTIMAL, MOVEMENT_MOVEMENT_KITING_DISTANCE
 
 MovementIntegration::MovementIntegration(::Player* bot)
     : _bot(bot)
@@ -35,7 +33,7 @@ void MovementIntegration::Update(uint32 diff, CombatSituation situation)
     _lastUpdate += diff;
     _currentSituation = situation;
 
-    if (_lastUpdate < UPDATE_INTERVAL)
+    if (_lastUpdate < MOVEMENT_UPDATE_INTERVAL)
         return;
 
     _lastUpdate = 0;
@@ -146,7 +144,7 @@ Position MovementIntegration::GetTargetPosition()
 float MovementIntegration::GetOptimalRange(::Unit* target)
 {
     if (!_bot || !target)
-        return MELEE_RANGE;
+        return MOVEMENT_MELEE_RANGE;
 
     CombatRole role = GetCombatRole();
 
@@ -154,16 +152,16 @@ float MovementIntegration::GetOptimalRange(::Unit* target)
     {
         case CombatRole::TANK:
         case CombatRole::MELEE_DPS:
-            return MELEE_RANGE;
+            return MOVEMENT_MELEE_RANGE;
 
         case CombatRole::HEALER:
             return 30.0f;  // Healing range
 
         case CombatRole::RANGED_DPS:
-            return RANGED_OPTIMAL;
+            return MOVEMENT_RANGED_OPTIMAL;
 
         default:
-            return MELEE_RANGE;
+            return MOVEMENT_MELEE_RANGE;
     }
 }
 
@@ -281,7 +279,7 @@ bool MovementIntegration::ShouldKite(::Unit* target)
     float distance = _bot->GetDistance(target);
 
     // Kite if target is too close
-    return distance < KITING_DISTANCE;
+    return distance < MOVEMENT_KITING_DISTANCE;
 }
 
 Position MovementIntegration::GetKitingPosition(::Unit* target)
@@ -291,7 +289,7 @@ Position MovementIntegration::GetKitingPosition(::Unit* target)
 
     // Move away from target
     float angle = target->GetAngle(_bot);
-    float distance = KITING_DISTANCE + 5.0f;  // Kite to safe distance
+    float distance = MOVEMENT_KITING_DISTANCE + 5.0f;  // Kite to safe distance
 
     float x = target->GetPositionX() + distance * ::std::cos(angle);
     float y = target->GetPositionY() + distance * ::std::sin(angle);

--- a/src/modules/Playerbot/AI/Combat/MovementIntegration.h
+++ b/src/modules/Playerbot/AI/Combat/MovementIntegration.h
@@ -21,6 +21,12 @@ class GameObject;
 namespace Playerbot
 {
 
+    // Movement Integration Constants
+    #define MOVEMENT_UPDATE_INTERVAL 200    // 200ms (5 FPS)
+    #define MOVEMENT_MELEE_RANGE 5.0f
+    #define MOVEMENT_RANGED_OPTIMAL 35.0f
+    #define MOVEMENT_KITING_DISTANCE 15.0f
+
     /**
      * @enum MovementUrgency
      * @brief Priority level for movement actions
@@ -336,11 +342,6 @@ namespace Playerbot
         MovementCommand _currentCommand;
         uint32 _lastUpdate;
         CombatSituation _currentSituation;
-
-        static constexpr uint32 UPDATE_INTERVAL = 200;  // 200ms (5 FPS)
-        static constexpr float MELEE_RANGE = 5.0f;
-        static constexpr float RANGED_OPTIMAL = 35.0f;
-        static constexpr float KITING_DISTANCE = 15.0f;
 
         /**
          * @brief Update danger zones (remove expired)


### PR DESCRIPTION
…fine constants

- Replaced static constexpr members with #define at namespace level
- MSVC doesn't fully support constexpr for float static class members
- Moved to preprocessor #define for maximum compatibility:
  - UPDATE_INTERVAL \u2192 MOVEMENT_UPDATE_INTERVAL
  - MELEE_RANGE \u2192 MOVEMENT_MELEE_RANGE
  - RANGED_OPTIMAL \u2192 MOVEMENT_RANGED_OPTIMAL
  - KITING_DISTANCE \u2192 MOVEMENT_KITING_DISTANCE
- Updated all references in MovementIntegration.cpp
- Fixes 12 MovementIntegration.h C2059 'Konstante' errors

Previous static constexpr approach still failed in MSVC. #define is more compatible and appropriate for compile-time constants.