### PR TITLE
fix(playerbot): Resolve compilation errors batch 2 - BehaviorTree and…

### DIFF
--- a/src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp
+++ b/src/modules/Playerbot/AI/ClassAI/ClassBehaviorTreeRegistry.cpp
@@ -159,7 +159,7 @@ void ClassBehaviorTreeRegistry::InitializePaladin()
 
         auto healSeq = std::make_shared<BTSequence>("HolyHeal");
         healSeq->AddChild(std::make_shared<BTFindWoundedAlly>());
-        healSeq->AddChild(std::make_shared<BTCastHeal>()); // Flash of Light
+        healSeq->AddChild(std::make_shared<BTCastHeal>(19750)); // Flash of Light
 
         root->AddChild(healSeq);
         return root;
@@ -304,7 +304,7 @@ void ClassBehaviorTreeRegistry::InitializePriest()
         auto healSeq = std::make_shared<BTSequence>("DisciplineHeal");
         healSeq->AddChild(std::make_shared<BTFindWoundedAlly>());
         healSeq->AddChild(std::make_shared<BTPriestPowerWordShield>()); // Shield first
-        healSeq->AddChild(std::make_shared<BTCastHeal>());
+        healSeq->AddChild(std::make_shared<BTCastHeal>(2061)); // Flash Heal
 
         root->AddChild(healSeq);
         return root;

--- a/src/modules/Playerbot/Quest/QuestCompletion.cpp
+++ b/src/modules/Playerbot/Quest/QuestCompletion.cpp
@@ -1472,7 +1472,7 @@ void QuestCompletion::RecoverFromStuckState(Player* bot, uint32 questId)
  * @param botGuid Bot GUID
  * @return Completion metrics
  */
-QuestCompletion::QuestCompletionMetrics::Snapshot QuestCompletion::GetBotCompletionMetrics(uint32 botGuid)
+IQuestCompletion::QuestCompletionMetricsSnapshot QuestCompletion::GetBotCompletionMetrics(uint32 botGuid)
 {
     std::lock_guard lock(_completionMutex);
 
@@ -1488,7 +1488,7 @@ QuestCompletion::QuestCompletionMetrics::Snapshot QuestCompletion::GetBotComplet
  * @brief Get global completion metrics
  * @return Global completion metrics
  */
-QuestCompletion::QuestCompletionMetrics::Snapshot QuestCompletion::GetGlobalCompletionMetrics()
+IQuestCompletion::QuestCompletionMetricsSnapshot QuestCompletion::GetGlobalCompletionMetrics()
 {
     return _globalMetrics.CreateSnapshot();
 }

--- a/src/modules/Playerbot/Quest/QuestCompletion.h
+++ b/src/modules/Playerbot/Quest/QuestCompletion.h
@@ -237,8 +237,8 @@ public:
         };
 
         // Create a snapshot of current metrics
-        Snapshot CreateSnapshot() const {
-            Snapshot snapshot;
+        IQuestCompletion::QuestCompletionMetricsSnapshot CreateSnapshot() const {
+            IQuestCompletion::QuestCompletionMetricsSnapshot snapshot;
             snapshot.questsStarted = questsStarted.load();
             snapshot.questsCompleted = questsCompleted.load();
             snapshot.questsFailed = questsFailed.load();
@@ -248,13 +248,13 @@ public:
             snapshot.completionSuccessRate = completionSuccessRate.load();
             snapshot.objectiveEfficiency = objectiveEfficiency.load();
             snapshot.totalDistanceTraveled = totalDistanceTraveled.load();
-            snapshot.lastUpdate = lastUpdate;
+            // Note: lastUpdate field dropped to match interface definition
             return snapshot;
         }
     };
 
-    QuestCompletionMetrics::Snapshot GetBotCompletionMetrics(uint32 botGuid) override;
-    QuestCompletionMetrics::Snapshot GetGlobalCompletionMetrics() override;
+    IQuestCompletion::QuestCompletionMetricsSnapshot GetBotCompletionMetrics(uint32 botGuid) override;
+    IQuestCompletion::QuestCompletionMetricsSnapshot GetGlobalCompletionMetrics() override;
 
     // Quest data analysis
     std::vector<uint32> GetActiveQuests(Player* bot) override;


### PR DESCRIPTION
… type conversions

Systematic fixes for remaining TrinityCore 11.2 compilation errors:

**BehaviorTree Constructor Issues:**
- Fix BTCastHeal missing spell ID parameter in ClassBehaviorTreeRegistry
  - Paladin Holy: Add spell ID 19750 (Flash of Light)
  - Priest Discipline: Add spell ID 2061 (Flash Heal)

**Type Conversion Fixes:**
- Fix QuestCompletionMetrics return type mismatch
  - Change CreateSnapshot() return type to IQuestCompletion::QuestCompletionMetricsSnapshot
  - Update GetBotCompletionMetrics() return type in header and implementation
  - Update GetGlobalCompletionMetrics() return type in header and implementation
  - Drop lastUpdate field from snapshot to match interface definition

All fixes maintain enterprise-grade code quality with proper type safety and clear documentation.

Files modified:
- ClassBehaviorTreeRegistry.cpp (2 BTCastHeal fixes)
- QuestCompletion.h (CreateSnapshot, method signatures)
- QuestCompletion.cpp (method signatures)