### PR TITLE
fix(playerbot): Correct include filename for RetributionSpecializatio…

### DIFF
--- a/src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp
+++ b/src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp
@@ -19,7 +19,7 @@
 
 #include "Paladins/HolyPaladinRefactored.h"
 #include "Paladins/ProtectionPaladinRefactored.h"
-#include "Paladins/RetributionPaladinRefactored.h"
+#include "Paladins/RetributionSpecializationRefactored.h"
 
 #include "Hunters/BeastMasteryHunterRefactored.h"
 #include "Hunters/MarksmanshipHunterRefactored.h"


### PR DESCRIPTION
…nRefactored

Fixed the last remaining compilation error (1/1):

Error: C1083 - Can't open include file "Paladins/RetributionPaladinRefactored.h"

Root Cause:
- File is named: RetributionSpecializationRefactored.h
- Class is named: RetributionPaladinRefactored
- Include was using class name instead of file name

Solution:
- Changed include from RetributionPaladinRefactored.h to RetributionSpecializationRefactored.h
- Class name RetributionPaladinRefactored remains correct in code

This completes the compilation error fixes:
- Batch 1-4: Fixed 3,288+ errors
- Circular dependency fix: Resolved 3,288 errors
- This fix: Resolves final error

Expected Result: 0 compilation errors!

Files Modified: 1
- src/modules/Playerbot/AI/ClassAI/SpecializedAIFactory.cpp