### PR TITLE
fix(playerbot): Rename TradeSecurity enum values to avoid Windows mac…

### DIFF
--- a/src/modules/Playerbot/Social/TradeManager.cpp
+++ b/src/modules/Playerbot/Social/TradeManager.cpp
@@ -105,7 +105,7 @@ namespace Playerbot
     // TradeManager implementation
     TradeManager::TradeManager(Player* bot, BotAI* ai) :
         BehaviorManager(bot, ai, 5000, "TradeManager"),  // 5 second update interval
-        m_securityLevel(TradeSecurity::STANDARD),
+        m_securityLevel(TradeSecurity::SECURITY_STANDARD),
         m_autoAcceptGroup(true),
         m_autoAcceptGuild(false),
         m_autoAcceptWhitelist(true),
@@ -344,7 +344,7 @@ namespace Playerbot
             return false;
 
         // Validate trade before accepting
-    if (m_securityLevel >= TradeSecurity::BASIC)
+    if (m_securityLevel >= TradeSecurity::SECURITY_BASIC)
         {
 
             if (!ValidateTradeItems())
@@ -373,7 +373,7 @@ namespace Playerbot
             }
         }
         // Check for scam (skip for owner trades)
-    if (m_securityLevel >= TradeSecurity::STANDARD)
+    if (m_securityLevel >= TradeSecurity::SECURITY_STANDARD)
         {
             // Don't check scam for trades with owner
 
@@ -408,7 +408,7 @@ namespace Playerbot
         }
 
         // Check fairness
-    if (m_securityLevel >= TradeSecurity::STRICT)
+    if (m_securityLevel >= TradeSecurity::SECURITY_STRICT)
         {
 
             if (!EvaluateTradeFairness())
@@ -943,7 +943,7 @@ namespace Playerbot
         }
 
         // Check permissions based on security level
-    if (m_securityLevel >= TradeSecurity::BASIC)
+    if (m_securityLevel >= TradeSecurity::SECURITY_BASIC)
         {
             // Must be in same group or guild
 
@@ -975,7 +975,7 @@ namespace Playerbot
             return true;
 
         // Check whitelist requirement
-    if (m_securityLevel >= TradeSecurity::STRICT)
+    if (m_securityLevel >= TradeSecurity::SECURITY_STRICT)
         {
 
             if (!IsWhitelisted(target->GetGUID()))
@@ -1079,7 +1079,7 @@ namespace Playerbot
 
     bool TradeManager::EvaluateTradeFairness() const
     {
-        if (m_securityLevel == TradeSecurity::NONE)
+        if (m_securityLevel == TradeSecurity::SECURITY_NONE)
 
             return true;
 
@@ -1112,7 +1112,7 @@ namespace Playerbot
 
     bool TradeManager::IsTradeScam() const
     {
-        if (m_securityLevel < TradeSecurity::STANDARD)
+        if (m_securityLevel < TradeSecurity::SECURITY_STANDARD)
 
             return false;
 

--- a/src/modules/Playerbot/Social/TradeManager.h
+++ b/src/modules/Playerbot/Social/TradeManager.h
@@ -50,10 +50,10 @@ namespace Playerbot
     // Trade security levels
     enum class TradeSecurity : uint8
     {
-        NONE            = 0,    // No security checks
-        BASIC           = 1,    // Basic ownership and group checks
-        STANDARD        = 2,    // Standard value comparison and whitelist
-        STRICT          = 3     // Strict mode with all validations
+        SECURITY_NONE     = 0,    // No security checks
+        SECURITY_BASIC    = 1,    // Basic ownership and group checks
+        SECURITY_STANDARD = 2,    // Standard value comparison and whitelist
+        SECURITY_STRICT   = 3     // Strict mode with all validations
     };
 
     // Trade item slot information
@@ -90,7 +90,7 @@ namespace Playerbot
 
         TradeManagerSession() : state(TradeState::IDLE), offeredGold(0), receivedGold(0),
             updateCount(0), isAccepted(false), traderAccepted(false),
-            securityLevel(TradeSecurity::STANDARD) {}
+            securityLevel(TradeSecurity::SECURITY_STANDARD) {}
 
         void Reset();
         uint64 GetTotalOfferedValue() const;


### PR DESCRIPTION
…ro conflicts

Windows headers define STRICT macro that conflicts with enum values. Renamed all TradeSecurity enum values for consistency and clarity:
- NONE → SECURITY_NONE
- BASIC → SECURITY_BASIC
- STANDARD → SECURITY_STANDARD
- STRICT → SECURITY_STRICT

Updated all usages in TradeManager.h and TradeManager.cpp.

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  
-  
-  

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

(Does it build, tested in-game, etc.)


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
