### PR TITLE
fix(playerbot): Make Lifecycle and TBB include directories PUBLIC for…

### DIFF
--- a/src/modules/Playerbot/CMakeLists.txt
+++ b/src/modules/Playerbot/CMakeLists.txt
@@ -1385,13 +1385,13 @@ target_include_directories(playerbot
         ${CMAKE_CURRENT_SOURCE_DIR}/Packets
         ${CMAKE_SOURCE_DIR}/src/modules/Common
         ${MYSQL_INCLUDE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/Lifecycle
+        ${PLAYERBOT_INCLUDE_DIRS}
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/Account
         ${CMAKE_CURRENT_SOURCE_DIR}/Character
-        ${CMAKE_CURRENT_SOURCE_DIR}/Lifecycle
         ${CMAKE_CURRENT_SOURCE_DIR}/Scripts
         ${CMAKE_CURRENT_BINARY_DIR}
-        ${PLAYERBOT_INCLUDE_DIRS}
 )
 
 # Link against TrinityCore and enterprise dependencies


### PR DESCRIPTION
… game library

BotSpawner.h is a public header included by World.cpp in the game library, but it uses TBB headers. Moving Lifecycle and PLAYERBOT_INCLUDE_DIRS (which contains TBB paths) from PRIVATE to PUBLIC so that any library linking against playerbot (like game) has access to TBB headers.

This fixes MSVC error: cannot open include file 'tbb/concurrent_hash_map.h'

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  
-  
-  

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

(Does it build, tested in-game, etc.)


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
