### PR TITLE
fix(playerbot): Link playerbot-dependencies as PUBLIC to propagate TB…

### DIFF
--- a/src/modules/Playerbot/CMakeLists.txt
+++ b/src/modules/Playerbot/CMakeLists.txt
@@ -1404,10 +1404,11 @@ target_link_libraries(playerbot
         common
         # Shared module libraries
         modules-common
-    PRIVATE
-        # Enterprise dependencies
-        ${PLAYERBOT_LIBRARIES}
+        # Enterprise dependencies (PUBLIC because BotSpawner.h uses TBB headers)
         playerbot-dependencies
+    PRIVATE
+        # Additional libraries
+        ${PLAYERBOT_LIBRARIES}
         # MySQL libraries for database connection
         ${MYSQL_LIBRARY}
 )


### PR DESCRIPTION
…B headers

BotSpawner.h is a public header that uses TBB types (concurrent_hash_map, concurrent_queue). The game library includes BotSpawner.h, so it needs access to TBB headers. Moving playerbot-dependencies from PRIVATE to PUBLIC ensures that TBB::tbb include directories are propagated to any target linking against playerbot.

This fixes MSVC error: cannot open include file 'tbb/concurrent_hash_map.h' when compiling World.cpp in game library.

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  
-  
-  

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

(Does it build, tested in-game, etc.)


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
