### PR TITLE
fix(playerbot): Implement missing IBotSpawner and IPlayerbotMigration…

### DIFF
--- a/src/modules/Playerbot/Database/PlayerbotMigrationMgr.cpp
+++ b/src/modules/Playerbot/Database/PlayerbotMigrationMgr.cpp
@@ -888,3 +888,57 @@ bool PlayerbotMigrationMgr::ApplyMigrationFile(MigrationFile const& migration)
 
     return true;
 }
+
+// Stub implementations for interface methods
+bool PlayerbotMigrationMgr::RollbackMigration(std::string const& version)
+{
+    TC_LOG_ERROR("playerbots.migration", "RollbackMigration not yet implemented for version {}", version);
+    return false;
+}
+
+bool PlayerbotMigrationMgr::ValidateSchema()
+{
+    TC_LOG_INFO("playerbots.migration", "ValidateSchema: Schema validation not yet implemented");
+    return true; // Return true for now to allow system to continue
+}
+
+bool PlayerbotMigrationMgr::ValidateVersion(std::string const& expectedVersion)
+{
+    std::string currentVersion = GetCurrentVersion();
+    bool isValid = (currentVersion == expectedVersion);
+
+    if (!isValid)
+    {
+        TC_LOG_WARN("playerbots.migration", "ValidateVersion: Version mismatch - Expected: {}, Current: {}",
+            expectedVersion, currentVersion);
+    }
+
+    return isValid;
+}
+
+bool PlayerbotMigrationMgr::BackupDatabase(std::string const& backupPath)
+{
+    TC_LOG_ERROR("playerbots.migration", "BackupDatabase not yet implemented (path: {})",
+        backupPath.empty() ? "default" : backupPath);
+    return false;
+}
+
+bool PlayerbotMigrationMgr::RestoreDatabase(std::string const& backupPath)
+{
+    TC_LOG_ERROR("playerbots.migration", "RestoreDatabase not yet implemented (path: {})", backupPath);
+    return false;
+}
+
+bool PlayerbotMigrationMgr::CanRollback(std::string const& version)
+{
+    // Check if migration exists and has been applied
+    if (!IsMigrationApplied(version))
+    {
+        TC_LOG_WARN("playerbots.migration", "CanRollback: Migration {} has not been applied", version);
+        return false;
+    }
+
+    // For now, we don't support rollback, so always return false
+    TC_LOG_WARN("playerbots.migration", "CanRollback: Rollback functionality not yet implemented for version {}", version);
+    return false;
+}


### PR DESCRIPTION
…Mgr interface methods

Added missing virtual function implementations to resolve linker errors:

BotSpawner.cpp:
- GetActiveBotCount(uint32 mapId, bool useMapId)
- IsBotActive(ObjectGuid guid)
- GetActiveBotsInZone(uint32 zoneId)
- GetAllZonePopulations()

PlayerbotMigrationMgr.cpp:
- RollbackMigration(version) - stub with error log
- ValidateSchema() - stub returning true
- ValidateVersion(expectedVersion) - validates against current version
- BackupDatabase(backupPath) - stub with error log
- RestoreDatabase(backupPath) - stub with error log
- CanRollback(version) - stub returning false

These functions were declared in interfaces but not implemented, causing LNK2001 unresolved external symbol errors in MSVC.

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  
-  
-  

**Issues addressed:**

Closes #  (insert issue tracker number)


**Tests performed:**

(Does it build, tested in-game, etc.)


**Known issues and TODO list:** (add/remove lines as needed)

- [ ] 
- [ ] 


<!--- Notes
- Enable the setting "[√] Allow edits from maintainers." when creating your pull request.
- If this PR only contains SQL files, open a new issue instead and post or link the SQL in the issue.
- When adding new SQL files, name them 9999_99_99_99_db_name.sql to reduce the chance of possible merge conflicts.
--->
